### PR TITLE
Fix a problem with removing Lookup table distortions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+# Compiled files
+*.py[co]
+*.a
+*.o
+*.so
+__pycache__
+
+# Other generated files
+*/version.py
+lib/stwcs/version.py
+htmlcov
+MANIFEST
+.coverage
+docs/api/
+MANIFEST
+
+# Sphinx
+docs/api
+docs/_build
+
+# Eclipse editor project files
+.project
+.pydevproject
+.settings
+
+# Pycharm editor project files
+.idea
+
+# Packages/installer info
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+distribute-*.tar.gz
+
+# Other
+.*.swp
+*~
+
+# Mac OSX
+.DS_Store

--- a/lib/stwcs/updatewcs/utils.py
+++ b/lib/stwcs/updatewcs/utils.py
@@ -255,7 +255,7 @@ def remove_distortion(fname, dist_keyword):
         for kw in keywords:
             try:
                 del f[hdu].header[kw]
-            except AttributeError:
+            except KeyError:
                 pass
     ext_mapping = altwcs.mapFitsExt2HDUListInd(fname, extname).values()
     ext_mapping.sort()


### PR DESCRIPTION
Catch a `KeyError` (not an `AttributeError`) when deleting header keywords. This fixes failing regression tests.