### PR TITLE
Fixes a bug (KeyError crash in applying headerlets using ``apply_as_primary``) revealed in Footprints ticket no. 9151

### DIFF
--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1988,10 +1988,8 @@ class Headerlet(fits.HDUList):
             # Update WCS with HDRNAME as well
 
             for kw in ['SIMPLE', 'BITPIX', 'NAXIS', 'EXTEND']:
-                try:
+                if kw in priwcs[0].header:
                     priwcs[0].header.remove(kw)
-                except ValueError:
-                    pass
 
             priwcs[0].header.set('WCSNAME', self[0].header['WCSNAME'], "")
             priwcs[0].header.set('WCSAXES', self[('SIPWCS', i)].header['WCSAXES'], "")


### PR DESCRIPTION
The old code would crash with ``KeyError`` if one of the header keywords intended to be deleted was not present in the header.