### PR TITLE
Catch info messages

### DIFF
--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -9,6 +9,8 @@ from .. import __version__
 
 from astropy import wcs as pywcs
 import astropy
+from astropy import log
+default_log_level = log.getEffectiveLevel()
 
 from . import utils, corrections
 from . import npol, det2im
@@ -210,7 +212,9 @@ def copyWCS(w, ehdr):
     WCS of the 'SCI' extension to the headers of 'ERR', 'DQ', 'SDQ',
     'TIME' or 'SAMP' extensions.
     """
+    log.setLevel('WARNING')
     hwcs = w.to_header()
+    log.setLevel(default_log_level)
 
     if w.wcs.has_cd():
         wcsutil.pc2cd(hwcs)

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import string
 import numpy as np
 from astropy import wcs as pywcs
+from astropy import log
 from astropy.io import fits
 from stsci.tools import fileutil as fu
 
@@ -120,7 +121,7 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
     else:
         wkey = wcskey
         wname = wcsname
-
+    log.setLevel('WARNING')
     for e in ext:
         hdr = _getheader(f, e)
         w = pywcs.WCS(hdr, f)
@@ -147,6 +148,7 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
         for k in hwcs.keys():
             key = k[: 7] + wkey
             f[e].header[key] = hwcs[k]
+    log.setLevel('DEBUG')
     closefobj(fname, f)
 
 
@@ -429,8 +431,9 @@ def _restore(fobj, ukey, fromextnum,
     # keep a copy of the ctype because of the "-SIP" suffix.
     ctype = hdr['ctype*']
     w = pywcs.WCS(hdr, fobj, key=ukey)
+    log.setLevel('WARNING')
     hwcs = w.to_header()
-
+    log.setLevel('DEBUG')
     if hwcs is None:
         return
 
@@ -513,7 +516,9 @@ def readAltWCS(fobj, ext, wcskey=' ', verbose=False):
             print('readAltWCS: Could not read WCS with key %s' % wcskey)
             print('            Skipping %s[%s]' % (fobj.filename(), str(ext)))
         return None
+    log.setLevel('WARNING')
     hwcs = nwcs.to_header()
+    log.setLevel('DEBUG')
 
     if nwcs.wcs.has_cd():
         hwcs = pc2cd(hwcs, key=wcskey)

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -3,9 +3,11 @@ from __future__ import absolute_import, division, print_function
 import string
 import numpy as np
 from astropy import wcs as pywcs
-from astropy import log
 from astropy.io import fits
 from stsci.tools import fileutil as fu
+
+from astropy import log
+default_log_level = log.getEffectiveLevel()
 
 altwcskw = ['WCSAXES', 'CRVAL', 'CRPIX', 'PC', 'CDELT', 'CD', 'CTYPE', 'CUNIT',
             'PV', 'PS']
@@ -148,7 +150,7 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
         for k in hwcs.keys():
             key = k[: 7] + wkey
             f[e].header[key] = hwcs[k]
-    log.setLevel('DEBUG')
+    log.setLevel(default_log_level)
     closefobj(fname, f)
 
 
@@ -433,7 +435,7 @@ def _restore(fobj, ukey, fromextnum,
     w = pywcs.WCS(hdr, fobj, key=ukey)
     log.setLevel('WARNING')
     hwcs = w.to_header()
-    log.setLevel('DEBUG')
+    log.setLevel(default_log_level)
     if hwcs is None:
         return
 
@@ -518,7 +520,7 @@ def readAltWCS(fobj, ext, wcskey=' ', verbose=False):
         return None
     log.setLevel('WARNING')
     hwcs = nwcs.to_header()
-    log.setLevel('DEBUG')
+    log.setLevel(default_log_level)
 
     if nwcs.wcs.has_cd():
         hwcs = pc2cd(hwcs, key=wcskey)

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -34,6 +34,9 @@ from . import wcscorr
 from .hstwcs import HSTWCS
 from .mappings import basic_wcs
 
+from astropy import log
+default_log_level = log.getEffectiveLevel()
+
 # Logging support functions
 
 
@@ -2144,6 +2147,8 @@ class Headerlet(fits.HDUList):
                     fobj.close()
                 raise ValueError(mess)
         numsip = countExtn(self, 'SIPWCS')
+
+        log.setLevel('WARNING')
         for idx in range(1, numsip + 1):
             siphdr = self[('SIPWCS', idx)].header
             tg_ext = (siphdr['TG_ENAME'], siphdr['TG_EVER'])
@@ -2164,6 +2169,8 @@ class Headerlet(fits.HDUList):
                 # fhdr.insert(wind, pyfits.Card(kw + wkey,
                 #                              self[0].header[kw]))
                 fhdr.append(fits.Card(kw + wkey, self[0].header[kw]))
+
+        log.setLevel(default_log_level)
         # Update the WCSCORR table with new rows from the headerlet's WCSs
         wcscorr.update_wcscorr(fobj, self, 'SIPWCS')
 

--- a/stwcs/wcsutil/hstwcs.py
+++ b/stwcs/wcsutil/hstwcs.py
@@ -12,6 +12,9 @@ from . import getinput
 from . import instruments
 from .mappings import inst_mappings, ins_spec_kw
 
+from astropy import log
+default_log_level = log.getEffectiveLevel()
+
 __all__ = ['HSTWCS']
 
 
@@ -382,8 +385,11 @@ class HSTWCS(WCS):
         sip2hdr : bool
             If True - include SIP coefficients
         """
-
+        if not relax and not sip2hdr:
+            log.setLevel('WARNING')
         h = self.to_header(key=wcskey, relax=relax)
+        log.setLevel(default_log_level)
+
         if not wcskey:
             wcskey = self.wcs.alt
         if self.wcs.has_cd():


### PR DESCRIPTION
`astropy.wcs` prints a log.info message when `wcs.to_header(relax=False)` is run. The messages informs that "-SIP" was stripped from `CTYPE`. Because `relax=False` means SIP should not be present in the returned header, there should be nothing unexpected in this behaviour. A proposed PR on `astropy` removes this message. 

The message is benign but creates a lot of confusion for drizzlepac users.
This PR catches this particular message so it's not printed when `drizzlepac` runs.