### PR TITLE
update to keep in sync with astropy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+1.3 (Unreleased)
+----------------
+
+- updatewcs() now reads all extension immediately after opening a file
+  to fix a problem after astropy implemented fits lazy loading. [#21]
+
 1.2.4 (2016-10-27)
 ------------------
 

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -116,6 +116,7 @@ def makecorr(fname, allowed_corr):
     """
     logger.info("Allowed corrections: {0}".format(allowed_corr))
     f = fits.open(fname, mode='update')
+    f.readall()
     # Determine the reference chip and create the reference HSTWCS object
     nrefchip, nrefext = getNrefchip(f)
     wcsutil.restoreWCS(f, nrefext, wcskey='O')


### PR DESCRIPTION
astropy/#5065 implements lazy loading of HDUs. This PR fixes some of the broken existing functionality bu reading all HDUs.