### PR TITLE
Remove header SIP keywords before reading AltWCS with non-SIP CTYPE

### DIFF
--- a/stwcs/tests/test_altwcs.py
+++ b/stwcs/tests/test_altwcs.py
@@ -89,7 +89,7 @@ class TestAltWCS(object):
 
     def test_restore_wcs(self):
         # test restore on a file
-        altwcs.restoreWCS(self.acs_file, ext=1, wcskey='O')
+        altwcs.restoreWCS(self.acs_file, ext=1, wcskey='O', basic=True)
         w1o = wcsutil.HSTWCS(self.acs_file, ext=1, wcskey='O')
         w1 = wcsutil.HSTWCS(self.acs_file, ext=1)
         compare_wcs(w1, w1o, exclude_keywords=['ctype'])

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -213,9 +213,7 @@ def copyWCS(w, ehdr):
     WCS of the 'SCI' extension to the headers of 'ERR', 'DQ', 'SDQ',
     'TIME' or 'SAMP' extensions.
     """
-    log.setLevel('WARNING')
-    hwcs = w.to_header()
-    log.setLevel(default_log_level)
+    hwcs = w.to_header(relax=False)
 
     if w.wcs.has_cd():
         wcsutil.pc2cd(hwcs)

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -119,7 +119,7 @@ def makecorr(fname, allowed_corr):
     f.readall()
     # Determine the reference chip and create the reference HSTWCS object
     nrefchip, nrefext = getNrefchip(f)
-    wcsutil.restoreWCS(f, nrefext, wcskey='O')
+    wcsutil.restoreWCS(f, nrefext, wcskey='O', basic=True)
     rwcs = wcsutil.HSTWCS(fobj=f, ext=nrefext)
     rwcs.readModel(update=True, header=f[nrefext].header)
 
@@ -134,14 +134,15 @@ def makecorr(fname, allowed_corr):
         if 'extname' in extn.header:
             extname = extn.header['extname'].lower()
             if extname == 'sci':
-                wcsutil.restoreWCS(f, ext=i, wcskey='O')
+                wcsutil.restoreWCS(f, ext=i, wcskey='O', basic=True)
                 sciextver = extn.header['extver']
                 ref_wcs = rwcs.deepcopy()
                 hdr = extn.header
                 ext_wcs = wcsutil.HSTWCS(fobj=f, ext=i)
                 # check if it exists first!!!
                 # 'O ' can be safely archived again because it has been restored first.
-                wcsutil.archiveWCS(f, ext=i, wcskey="O", wcsname="OPUS", reusekey=True)
+                wcsutil.archiveWCS(f, ext=i, wcskey="O", wcsname="OPUS",
+                                   reusekey=True, basic=True)
                 ext_wcs.readModel(update=True, header=hdr)
                 for c in allowed_corr:
                     if c != 'NPOLCorr' and c != 'DET2IMCorr':
@@ -371,8 +372,10 @@ def cleanWCS(fname):
         pass
     fext = list(range(1, len(f)))
     for key in keys:
+        if key == 'O':
+            continue
         try:
-            wcsutil.deleteWCS(fname, ext=fext, wcskey=key)
+            wcsutil.deleteWCS(fname, ext=fext, wcskey=key, basic=False)
         except KeyError:
             # Some extensions don't have the alternate (or any) WCS keywords
             continue

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -435,16 +435,15 @@ def _restore(fobj, ukey, fromextnum,
 
     # remove SIP before reading a non-SIP WCS to surpress warning message,
     # see https://github.com/spacetelescope/stwcs/issues/25 :
-    ctype1_kwd = 'CTYPE1' + ukey
+    ctype1_kwd = 'CTYPE1' + ukey.strip()
     ctype1 = hdr[ctype1_kwd].strip().upper() if ctype1_kwd in hdr else '-SIP'
-    if not ctype1.endswith('-SIP'):
+    hdrc = hdr
+    if ukey.strip() == 'O' and not ctype1.endswith('-SIP'):
         hdrc = hdr.copy()
         if 'A_ORDER' in hdrc:
             del hdrc['A_ORDER']
         if 'B_ORDER' in hdrc:
             del hdrc['B_ORDER']
-    else:
-        hdrc = hdr
 
     w = pywcs.WCS(hdrc, fobj, key=ukey)
 
@@ -527,9 +526,9 @@ def readAltWCS(fobj, ext, wcskey=' ', verbose=False):
 
     # remove SIP before reading a non-SIP WCS to surpress warning message,
     # see https://github.com/spacetelescope/stwcs/issues/25 :
-    ctype1_kwd = 'CTYPE1' + wcskey
+    ctype1_kwd = 'CTYPE1' + wcskey.strip()
     ctype1 = hdr[ctype1_kwd].strip().upper() if ctype1_kwd in hdr else '-SIP'
-    if not ctype1.endswith('-SIP'):
+    if wcskey.strip() == 'O' and not ctype1.endswith('-SIP'):
         if 'A_ORDER' in hdr:
             del hdr['A_ORDER']
         if 'B_ORDER' in hdr:

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -436,7 +436,7 @@ def _restore(fobj, ukey, fromextnum,
 
     w = pywcs.WCS(hdrc, fobj, key=ukey)
 
-    hwcs = w.to_header()
+    hwcs = w.to_header(relax=False)
 
     if hwcs is None:
         return

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -435,10 +435,11 @@ def _restore(fobj, ukey, fromextnum,
 
     # remove SIP before reading a non-SIP WCS to surpress warning message,
     # see https://github.com/spacetelescope/stwcs/issues/25 :
-    ctype1_kwd = 'CTYPE1' + ukey.strip()
+    u_key = ukey.strip().upper()
+    ctype1_kwd = 'CTYPE1' + u_key
     ctype1 = hdr[ctype1_kwd].strip().upper() if ctype1_kwd in hdr else '-SIP'
     hdrc = hdr
-    if ukey.strip() == 'O' and not ctype1.endswith('-SIP'):
+    if u_key == 'O' and not ctype1.endswith('-SIP'):
         hdrc = hdr.copy()
         if 'A_ORDER' in hdrc:
             del hdrc['A_ORDER']
@@ -526,9 +527,10 @@ def readAltWCS(fobj, ext, wcskey=' ', verbose=False):
 
     # remove SIP before reading a non-SIP WCS to surpress warning message,
     # see https://github.com/spacetelescope/stwcs/issues/25 :
-    ctype1_kwd = 'CTYPE1' + wcskey.strip()
+    u_key = wcskey.strip().upper()
+    ctype1_kwd = 'CTYPE1' + u_key
     ctype1 = hdr[ctype1_kwd].strip().upper() if ctype1_kwd in hdr else '-SIP'
-    if wcskey.strip() == 'O' and not ctype1.endswith('-SIP'):
+    if u_key == 'O' and not ctype1.endswith('-SIP'):
         if 'A_ORDER' in hdr:
             del hdr['A_ORDER']
         if 'B_ORDER' in hdr:

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -123,11 +123,11 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
     else:
         wkey = wcskey
         wname = wcsname
-    log.setLevel('WARNING')
+
     for e in ext:
         hdr = _getheader(f, e)
         w = pywcs.WCS(hdr, f)
-        hwcs = w.to_header()
+        hwcs = w.to_header(relax=False)
 
         if hwcs is None:
             continue
@@ -150,7 +150,7 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
         for k in hwcs.keys():
             key = k[: 7] + wkey
             f[e].header[key] = hwcs[k]
-    log.setLevel(default_log_level)
+
     closefobj(fname, f)
 
 
@@ -545,7 +545,7 @@ def readAltWCS(fobj, ext, wcskey=' ', verbose=False):
             print('            Skipping %s[%s]' % (fobj.filename(), str(ext)))
         return None
 
-    hwcs = nwcs.to_header()
+    hwcs = nwcs.to_header(relax=False)
 
     if nwcs.wcs.has_cd():
         hwcs = pc2cd(hwcs, key=wcskey)

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -448,9 +448,7 @@ def _restore(fobj, ukey, fromextnum,
 
     w = pywcs.WCS(hdrc, fobj, key=ukey)
 
-    log.setLevel('WARNING')
     hwcs = w.to_header()
-    log.setLevel(default_log_level)
     if hwcs is None:
         return
 
@@ -545,9 +543,7 @@ def readAltWCS(fobj, ext, wcskey=' ', verbose=False):
             print('            Skipping %s[%s]' % (fobj.filename(), str(ext)))
         return None
 
-    log.setLevel('WARNING')
     hwcs = nwcs.to_header()
-    log.setLevel(default_log_level)
 
     if nwcs.wcs.has_cd():
         hwcs = pc2cd(hwcs, key=wcskey)

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -481,7 +481,7 @@ def _filtered_SIP_header(hdr, key):
         ctype2_has_sip = (ctype2_kwd in hdr and
                           hdr[ctype2_kwd].strip().upper().endswith('-SIP'))
 
-        if ctype1_has_sip and ctype2_has_sip:
+        if not (ctype1_has_sip and ctype2_has_sip):
             hdrc = hdr.copy()
             if 'A_ORDER' in hdrc:
                 del hdrc['A_ORDER']

--- a/stwcs/wcsutil/convertwcs.py
+++ b/stwcs/wcsutil/convertwcs.py
@@ -47,7 +47,7 @@ def archive_prefix_OPUS_WCS(fobj, extname='SCI'):
     # Insure that the 'O' alternate WCS is present
     if 'O' not in wcsutil.wcskeys(hdr):
         # if not, archive the Primary WCS as the default OPUS WCS
-        wcsutil.archiveWCS(fobj, extlist, wcskey='O', wcsname='OPUS')
+        wcsutil.archiveWCS(fobj, extlist, wcskey='O', wcsname='OPUS', basic=True)
 
     # find out how many SCI extensions are in the image
     numextn = fileutil.countExtn(fobj, extname=extname)

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1968,7 +1968,7 @@ class Headerlet(fits.HDUList):
                             priwcs_name = 'UNKNOWN'
                 nextkey = altwcs.next_wcskey(fobj, ext=target_ext)
                 altwcs.archiveWCS(fobj, ext=sciext_list, wcskey=nextkey,
-                                  wcsname=priwcs_name)
+                                  wcsname=priwcs_name, basic=True)
             else:
 
                 for hname in altwcs.wcsnames(fobj, ext=target_ext).values():
@@ -2567,7 +2567,7 @@ class Headerlet(fits.HDUList):
         logger.debug("Removing alternate WCSs with keys %s from %s"
                      % (dkeys, dest.filename()))
         for k in dkeys:
-            altwcs.deleteWCS(dest, ext=ext, wcskey=k)
+            altwcs.deleteWCS(dest, ext=ext, wcskey=k, basic=False)
 
     def _remove_primary_WCS(self, ext):
         """

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -2155,14 +2155,13 @@ class Headerlet(fits.HDUList):
                 raise ValueError(mess)
         numsip = countExtn(self, 'SIPWCS')
 
-        log.setLevel('WARNING')
         for idx in range(1, numsip + 1):
             siphdr = self[('SIPWCS', idx)].header
             tg_ext = (siphdr['TG_ENAME'], siphdr['TG_EVER'])
 
             fhdr = fobj[tg_ext].header
             hwcs = pywcs.WCS(siphdr, self)
-            hwcs_header = hwcs.to_header(key=wkey)
+            hwcs_header = hwcs.to_header(key=wkey, relax=False)
             _idc2hdr(siphdr, fhdr, towkey=wkey)
             if hwcs.wcs.has_cd():
                 hwcs_header = altwcs.pc2cd(hwcs_header, key=wkey)
@@ -2177,7 +2176,6 @@ class Headerlet(fits.HDUList):
                 #                              self[0].header[kw]))
                 fhdr.append(fits.Card(kw + wkey, self[0].header[kw]))
 
-        log.setLevel(default_log_level)
         # Update the WCSCORR table with new rows from the headerlet's WCSs
         wcscorr.update_wcscorr(fobj, self, 'SIPWCS')
 

--- a/stwcs/wcsutil/hstwcs.py
+++ b/stwcs/wcsutil/hstwcs.py
@@ -385,13 +385,14 @@ class HSTWCS(WCS):
         sip2hdr : bool
             If True - include SIP coefficients
         """
-        if not relax and not sip2hdr:
-            log.setLevel('WARNING')
+        if relax is None:
+            relax = False
+
         h = self.to_header(key=wcskey, relax=relax)
-        log.setLevel(default_log_level)
 
         if not wcskey:
             wcskey = self.wcs.alt
+
         if self.wcs.has_cd():
             h = pc2cd(h, key=wcskey)
 

--- a/stwcs/wcsutil/mosaic.py
+++ b/stwcs/wcsutil/mosaic.py
@@ -89,20 +89,24 @@ def vmosaic(fnames, outwcs=None, ref_wcs=None, ext=None, extname=None, undistort
 def updatehdr(fname, wcsobj, wkey, wcsname, ext=1, clobber=False):
     hdr = fits.getheader(fname, ext=ext)
     all_keys = list(string.ascii_uppercase)
+
     if wkey.upper() not in all_keys:
         raise KeyError("wkey must be one character: A-Z")
+
     if wkey not in altwcs.available_wcskeys(hdr):
         if not clobber:
             raise ValueError("wkey {0} is already in use."
                              "Use clobber=True to overwrite it or"
                              "specify a different key.".format(wkey))
         else:
-            altwcs.deleteWCS(fname, ext=ext, wcskey='V')
+            altwcs.deleteWCS(fname, ext=ext, wcskey='V', basic=False)
+
     f = fits.open(fname, mode='update')
 
     hwcs = wcs2header(wcsobj)
     wcsnamekey = 'WCSNAME' + wkey
     f[ext].header[wcsnamekey] = wcsname
+
     for k in hwcs:
         f[ext].header[k[: 7] + wkey] = hwcs[k]
 

--- a/stwcs/wcsutil/wcscorr.py
+++ b/stwcs/wcsutil/wcscorr.py
@@ -99,7 +99,8 @@ def init_wcscorr(input, force=False):
         # if so, get its values directly, otherwise, archive the PRIMARY WCS
         # as the OPUS values in the WCSCORR table
         if 'O' not in used_wcskeys:
-            altwcs.archiveWCS(fimg, ('SCI', extver), wcskey='O', wcsname='OPUS')
+            altwcs.archiveWCS(fimg, ('SCI', extver), wcskey='O',
+                              wcsname='OPUS', basic=True)
         wkey = 'O'
 
         wcs = stwcs.wcsutil.HSTWCS(fimg, ext=('SCI', extver), wcskey=wkey)


### PR DESCRIPTION
This PR addresses issue https://github.com/spacetelescope/stwcs/issues/25 by deleting ``A/B_ORDER`` keywords from headers before reading alternative WCSes whose ``CTYPE`` does not contain ``-SIP`` postfix. This turns off long ``INFO`` messages from ``astropy.wcs.WCS()``.