### PR TITLE
Switch from string.uppercase to string.ascii_uppercase

### DIFF
--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -112,7 +112,7 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
                     if ' ' in wnames:
                         wname = wnames[' ']
                     else:
-                        akeys = string.uppercase
+                        akeys = string.ascii_uppercase
                         wname = "DEFAULT"
                         for key in akeys[-1::]:
                             if key in wnames:


### PR DESCRIPTION
This PR addresses a Python 3 compatibility issue described in https://github.com/spacetelescope/stwcs/issues/29