### PR TITLE
suppress warning messages when it's known they are not relevant

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - The ``clobber`` parameter in `Headerlet.tofile()`` was replaced with
   ``overwrite``. [#24]
+- Fixed a python compatibility bug. [#30]
+-
 
 1.2.5 (2016-12-20)
 ----------------
@@ -10,8 +12,10 @@
 - updatewcs() now reads all extension immediately after opening a file
   to fix a problem after astropy implemented fits lazy loading. [#21]
 
-- Fixed a bug in updating the D2IM correction in a science file when the 
+- Fixed a bug in updating the D2IM correction in a science file when the
   a new distortion file was supplied through D2IMFILE keyword. [#22]
+
+- Warning messages from astropy.wcs are filtered out when they are not relevant. [#31]
 
 1.2.4 (2016-10-27)
 ------------------

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -149,7 +149,6 @@ def makecorr(fname, allowed_corr):
                 ext_wcs = wcsutil.HSTWCS(fobj=f, ext=i)
                 # check if it exists first!!!
                 # 'O ' can be safely archived again because it has been restored first.
-                # perhaps archive only if it doesn't exist???
                 wcsutil.archiveWCS(f, ext=i, wcskey="O", wcsname="OPUS", reusekey=True)
 
                 ext_wcs.readModel(update=True, header=hdr)

--- a/stwcs/updatewcs/apply_corrections.py
+++ b/stwcs/updatewcs/apply_corrections.py
@@ -249,7 +249,7 @@ def apply_d2im_correction(fname, d2imcorr):
         return False
     fd2im0 = fileutil.osfn(fd2im0)
     if not fileutil.findFile(fd2im0):
-        message = "D2IMFILE {0} not found.".format(fname)
+        message = "D2IMFILE {0} not found.".format(fd2im0)
         logger.critical(message)
         raise IOError(message)
     try:

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -159,7 +159,6 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
             key = k[: 7] + wkey
             f[e].header[key] = hwcs[k]
     log.setLevel(default_log_level)
-    warnings.resetwarnings()
     closefobj(fname, f)
 
 

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import string
+import warnings
 import numpy as np
 from astropy import wcs as pywcs
 from astropy.io import fits
@@ -8,6 +9,13 @@ from stsci.tools import fileutil as fu
 
 from astropy import log
 default_log_level = log.getEffectiveLevel()
+
+warnings.filterwarnings("ignore", message="^Some non-standard WCS keywords were excluded:", module="astropy.wcs.wcs")
+
+
+__all__ = ["archiveWCS", "available_wcskeys", "convertAltWCS", "deleteWCS", "next_wcskey",
+           "pc2cd", "readAltWCS", "restoreWCS", "wcskeys", "wcsnames"]
+
 
 altwcskw = ['WCSAXES', 'CRVAL', 'CRPIX', 'PC', 'CDELT', 'CD', 'CTYPE', 'CUNIT',
             'PV', 'PS']
@@ -151,6 +159,7 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
             key = k[: 7] + wkey
             f[e].header[key] = hwcs[k]
     log.setLevel(default_log_level)
+    warnings.resetwarnings()
     closefobj(fname, f)
 
 
@@ -432,10 +441,9 @@ def _restore(fobj, ukey, fromextnum,
     hdr = _getheader(fobj, fromextension)
     # keep a copy of the ctype because of the "-SIP" suffix.
     ctype = hdr['ctype*']
+
     w = pywcs.WCS(hdr, fobj, key=ukey)
-    log.setLevel('WARNING')
     hwcs = w.to_header()
-    log.setLevel(default_log_level)
     if hwcs is None:
         return
 
@@ -518,9 +526,7 @@ def readAltWCS(fobj, ext, wcskey=' ', verbose=False):
             print('readAltWCS: Could not read WCS with key %s' % wcskey)
             print('            Skipping %s[%s]' % (fobj.filename(), str(ext)))
         return None
-    log.setLevel('WARNING')
     hwcs = nwcs.to_header()
-    log.setLevel(default_log_level)
 
     if nwcs.wcs.has_cd():
         hwcs = pc2cd(hwcs, key=wcskey)

--- a/stwcs/wcsutil/hstwcs.py
+++ b/stwcs/wcsutil/hstwcs.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import warnings
 from astropy.wcs import WCS
 from astropy.io import fits
 from ..distortion import models, coeff_converter
@@ -17,6 +18,7 @@ default_log_level = log.getEffectiveLevel()
 
 __all__ = ['HSTWCS']
 
+warnings.filterwarnings("ignore", message="^Some non-standard WCS keywords were excluded:", module="astropy.wcs.wcs")
 
 def extract_rootname(kwvalue, suffix=""):
     """ Returns the rootname from a full reference filename
@@ -385,10 +387,8 @@ class HSTWCS(WCS):
         sip2hdr : bool
             If True - include SIP coefficients
         """
-        if not relax and not sip2hdr:
-            log.setLevel('WARNING')
+        warnings.filterwarnings("ignore", message="^Some non-standard WCS keywords were excluded:", module="astropy.wcs")
         h = self.to_header(key=wcskey, relax=relax)
-        log.setLevel(default_log_level)
 
         if not wcskey:
             wcskey = self.wcs.alt


### PR DESCRIPTION
This closes #25 #26 but takes a different approach. The warnings are filtered out. It's safe to do this because only one specific warning is filtered out and only in cases when it's not relevant.