### PR TITLE
Remove print statement on package import when TEAL tasknames not found

### DIFF
--- a/stwcs/__init__.py
+++ b/stwcs/__init__.py
@@ -1,15 +1,14 @@
 """ STWCS
 
 This package provides support for WCS based distortion models and coordinate
-transformation. It relies on PyWCS (based on WCSLIB). It consists of two
-subpackages:  updatewcs and wcsutil.
+transformation. It relies on astropy.wcs (based on WCSLIB). It consists of
+two subpackages:  updatewcs and wcsutil.
 
-updatewcs performs corrections to the
-basic WCS and includes other distortion infomation in the science files as
-header keywords or file extensions.
+updatewcs performs corrections to the basic WCS and includes other distortion
+infomation in the science files as header keywords or file extensions.
 
-Wcsutil provides an HSTWCS object which extends pywcs.WCS object and provides
-HST instrument specific information as well as methods for coordinate
+Wcsutil provides an HSTWCS object which extends astropy.wcs.WCS object and
+provides HST instrument specific information as well as methods for coordinate
 transformation. wcsutil also provides functions for manipulating alternate WCS
 descriptions in the headers.
 
@@ -21,7 +20,6 @@ from . import distortion
 from stsci.tools import fileutil
 from stsci.tools import teal
 
-
 from .version import *
 
 try:
@@ -29,4 +27,4 @@ try:
     teal.print_tasknames(gui.__name__, os.path.dirname(gui.__file__))
     print('\n')
 except:
-    print('No TEAL-based tasks available for this package!')
+    pass


### PR DESCRIPTION
- Prevent unnecessary TEAL-related printing on package import
- Update docstring to refer to `astropy.wcs` instead of `pywcs`