### PR TITLE
remove py 2 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ env:
         - PIP_DEPENDENCIES=""
 
     matrix:
-        - PYTHON_VERSION=2.7 SETUP_CMD='install'
         - PYTHON_VERSION=3.5 SETUP_CMD='install'
-        - PYTHON_VERSION=2.7 SETUP_CMD='test'
         - PYTHON_VERSION=3.5 SETUP_CMD='test'
 
 install:


### PR DESCRIPTION
As of Sep 21st `astropy` has dropped support for Python 2.
This PR updates the Travis matrix to not test on Python 2.