### PR TITLE
make sure stwcs does not install on py2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,13 @@
 STWCS
 -----
 
+
 `STWCS <http://ssb.stsci.edu/doc/stsci_python_dev/stwcs.doc/html/index.html>`__ provides support for WCS distortion models and coordinate
 transformation for the imaging instruments on the Hubble Space Telescope (HST).
 
+Note
+----
+Starting with version 1.4, STWCS requires Python 3.5 and above.
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,20 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
+
+if sys.version_info < (3, 5):
+    error = """
+    STWCS 1.4+ does not support Python 2.x, 3.0, 3.1, 3.2, 3.3 or 3.4.
+    Beginning with STWCS 1.4.0, Python 3.5 and above is required.
+
+    This may be due to an out of date pip.
+
+    Make sure you have pip >= 9.0.1.
+
+    """
+    sys.exit(error)
+
+
 if os.path.exists('relic'):
     sys.path.insert(1, 'relic')
     import relic.release

--- a/stwcs/__init__.py
+++ b/stwcs/__init__.py
@@ -13,7 +13,6 @@ transformation. wcsutil also provides functions for manipulating alternate WCS
 descriptions in the headers.
 
 """
-from __future__ import absolute_import, print_function # confidence high
 import os
 
 from . import distortion

--- a/stwcs/distortion/coeff_converter.py
+++ b/stwcs/distortion/coeff_converter.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, unicode_literals, division, print_function)
-
 import numpy as np
 from astropy.io import fits
 from astropy import wcs as pywcs

--- a/stwcs/distortion/models.py
+++ b/stwcs/distortion/models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numpy as np
 from . import mutil
 from .mutil import combin

--- a/stwcs/distortion/mutil.py
+++ b/stwcs/distortion/mutil.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 from stsci.tools import fileutil
 import numpy as np
 import calendar

--- a/stwcs/distortion/utils.py
+++ b/stwcs/distortion/utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 
 import numpy as np

--- a/stwcs/gui/__init__.py
+++ b/stwcs/gui/__init__.py
@@ -4,10 +4,8 @@ This package defines the TEAL interfaces for public, file-based operations
 provided by the STWCS package.
 
 """
-from __future__ import absolute_import # confidence high
-__docformat__ = 'restructuredtext'
 
-# import modules which define the TEAL interfaces 
+# import modules which define the TEAL interfaces
 from . import write_headerlet
 from . import extract_headerlet
 from . import attach_headerlet

--- a/stwcs/gui/apply_headerlet.py
+++ b/stwcs/gui/apply_headerlet.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import os
 from stsci.tools import teal, parseinput
 

--- a/stwcs/gui/archive_headerlet.py
+++ b/stwcs/gui/archive_headerlet.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import os
 
 from stsci.tools import teal

--- a/stwcs/gui/attach_headerlet.py
+++ b/stwcs/gui/attach_headerlet.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import os
 
 from stsci.tools import teal

--- a/stwcs/gui/delete_headerlet.py
+++ b/stwcs/gui/delete_headerlet.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 from stsci.tools import teal
 from stsci.tools import parseinput

--- a/stwcs/gui/extract_headerlet.py
+++ b/stwcs/gui/extract_headerlet.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 
 from stsci.tools import teal

--- a/stwcs/gui/headerlet_summary.py
+++ b/stwcs/gui/headerlet_summary.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import os
 from stsci.tools import teal
 

--- a/stwcs/gui/restore_headerlet.py
+++ b/stwcs/gui/restore_headerlet.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import os
 
 from stsci.tools import teal

--- a/stwcs/gui/updatewcs.py
+++ b/stwcs/gui/updatewcs.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 
 from astropy.io import fits

--- a/stwcs/gui/write_headerlet.py
+++ b/stwcs/gui/write_headerlet.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import os
 
 from stsci.tools import teal

--- a/stwcs/tests/test_altwcs.py
+++ b/stwcs/tests/test_altwcs.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import shutil
 import os
 from astropy.io import fits as pyfits

--- a/stwcs/tests/test_astrometrydb.py
+++ b/stwcs/tests/test_astrometrydb.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import shutil
 import os
 

--- a/stwcs/tests/test_headerlet.py
+++ b/stwcs/tests/test_headerlet.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import shutil
 import os
 import io

--- a/stwcs/tests/test_hstwcs.py
+++ b/stwcs/tests/test_hstwcs.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 from astropy.io import fits
 from ..wcsutil import hstwcs
 

--- a/stwcs/tests/test_updatewcs.py
+++ b/stwcs/tests/test_updatewcs.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import shutil
 import os
 

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import atexit
 import warnings
 

--- a/stwcs/updatewcs/apply_corrections.py
+++ b/stwcs/updatewcs/apply_corrections.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os.path
 from astropy.io import fits
 from stsci.tools import fileutil

--- a/stwcs/updatewcs/corrections.py
+++ b/stwcs/updatewcs/corrections.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import copy
 import datetime
 import logging
@@ -166,7 +164,7 @@ class TDDCorr(object):
             hwcs.idcmodel.cy[1, 1] = new_beta
         logger.info("CY11: {0} based on alpha: {1}, beta: {2}".format(hwcs.idcmodel.cy[1, 1],
                                                                       cy_alpha, cy_beta))
-        
+
         cx_beta = skew_coeffs['TDD_CX_BETA']
         cx_alpha = skew_coeffs['TDD_CX_ALPHA']
         if cx_alpha is not None:

--- a/stwcs/updatewcs/det2im.py
+++ b/stwcs/updatewcs/det2im.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 from astropy.io import fits
 from stsci.tools import fileutil
 

--- a/stwcs/updatewcs/makewcs.py
+++ b/stwcs/updatewcs/makewcs.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import numpy as np
 import logging
 import time

--- a/stwcs/updatewcs/npol.py
+++ b/stwcs/updatewcs/npol.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import logging
 import time
 

--- a/stwcs/updatewcs/utils.py
+++ b/stwcs/updatewcs/utils.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import os
 from astropy.io import fits
 from stsci.tools import fileutil

--- a/stwcs/updatewcs/wfpc2_dgeo.py
+++ b/stwcs/updatewcs/wfpc2_dgeo.py
@@ -1,7 +1,6 @@
 """ wfpc2_dgeo - Functions to convert WFPC2 DGEOFILE into D2IMFILE
 
 """
-from __future__ import absolute_import, division, print_function
 import os
 import datetime
 

--- a/stwcs/wcsutil/__init__.py
+++ b/stwcs/wcsutil/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 from .altwcs import *
 from .hstwcs import HSTWCS
 

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import string
 import warnings
 import numpy as np

--- a/stwcs/wcsutil/convertwcs.py
+++ b/stwcs/wcsutil/convertwcs.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 from astropy.io import fits
 try:
     import stwcs

--- a/stwcs/wcsutil/getinput.py
+++ b/stwcs/wcsutil/getinput.py
@@ -1,8 +1,5 @@
-from __future__ import absolute_import, division, print_function
-
 from astropy.io import fits
 from stsci.tools import irafglob, fileutil, parseinput
-#from . import HSTWCS
 
 
 def parseSingleInput(f=None, ext=None):

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -9,8 +9,6 @@ that would not require getting entirely new images from the archive
 when only the WCS information has been updated.
 
 """
-
-from __future__ import absolute_import, division, print_function
 import os
 import sys
 import functools

--- a/stwcs/wcsutil/hstwcs.py
+++ b/stwcs/wcsutil/hstwcs.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 import warnings
 from astropy.wcs import WCS

--- a/stwcs/wcsutil/instruments.py
+++ b/stwcs/wcsutil/instruments.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 
 class InstrWCS(object):
     """

--- a/stwcs/wcsutil/mappings.py
+++ b/stwcs/wcsutil/mappings.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 # This dictionary maps an instrument into an instrument class
 # The instrument class handles instrument specific keywords
 

--- a/stwcs/wcsutil/mosaic.py
+++ b/stwcs/wcsutil/mosaic.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import numpy as np
 from matplotlib import pyplot as plt
 from astropy.io import fits

--- a/stwcs/wcsutil/wcscorr.py
+++ b/stwcs/wcsutil/wcscorr.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import copy
 import numpy as np
 from astropy.io import fits

--- a/stwcs/wcsutil/wcsdiff.py
+++ b/stwcs/wcsutil/wcsdiff.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 from astropy import wcs as pywcs
 from collections import OrderedDict
 from astropy.io import fits


### PR DESCRIPTION
Make sure that `stwcs` does not install on python 2.
Update `README` with supported python versions.