### PR TITLE
Initial commit of support for HDUList objects as inputs to updatewcs

### DIFF
--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -411,7 +411,7 @@ def cleanWCS(fname):
     fext = list(range(1, len(f)))
     for key in keys:
         try:
-            wcsutil.deleteWCS(fname, ext=fext, wcskey=key)
+            wcsutil.deleteWCS(fname.hdulist, ext=fext, wcskey=key)
         except KeyError:
             # Some extensions don't have the alternate (or any) WCS keywords
             continue

--- a/stwcs/updatewcs/apply_corrections.py
+++ b/stwcs/updatewcs/apply_corrections.py
@@ -35,6 +35,9 @@ def setCorrections(fname, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=Tru
     based on user input paramters and allowed corrections
     for the instrument.
     """
+    # Insure input is the correct type
+    fname = utils.get_file(fname)
+
     instrument = fname.getval('INSTRUME')
     # make a copy of this list
     acorr = allowed_corrections[instrument][:]
@@ -215,8 +218,8 @@ def apply_d2im_correction(fname, d2imcorr):
 
     Parameters
     ----------
-    fname : str
-        Science file name.
+    fname : str or obj
+        Science file name or ``updatewcs.utils.FITSObject`` or FITS HDUList.
     d2imcorr : bool
         Flag indicating if D2IM is should be enabled if allowed.
 
@@ -236,6 +239,9 @@ def apply_d2im_correction(fname, d2imcorr):
     if not d2imcorr:
         logger.info("D2IM correction not requested - not applying it.")
         return False
+    # Insure input is in the proper format
+    fname = utils.get_file(fname)
+
     # get D2IMFILE kw from primary header
     try:
         fd2im0 = fname.getval('D2IMFILE')

--- a/stwcs/updatewcs/apply_corrections.py
+++ b/stwcs/updatewcs/apply_corrections.py
@@ -35,7 +35,7 @@ def setCorrections(fname, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=Tru
     based on user input paramters and allowed corrections
     for the instrument.
     """
-    instrument = fits.getval(fname, 'INSTRUME')
+    instrument = fname.getval('INSTRUME')
     # make a copy of this list
     acorr = allowed_corrections[instrument][:]
 
@@ -87,7 +87,7 @@ def foundIDCTAB(fname):
     """
 
     try:
-        idctab = fits.getval(fname, 'IDCTAB').strip()
+        idctab = fname.getval('IDCTAB').strip()
         if idctab == 'N/A' or idctab == "":
             return False
     except KeyError:
@@ -108,7 +108,7 @@ def applyTDDCorr(fname, utddcorr):
     - the idc table specified in the primary header is available.
     """
 
-    phdr = fits.getheader(fname)
+    phdr = fname.getheader()
     instrument = phdr['INSTRUME']
     try:
         detector = phdr['DETECTOR']
@@ -149,7 +149,7 @@ def applyNpolCorr(fname, unpolcorr):
     applyNPOLCorr = True
     try:
         # get NPOLFILE kw from primary header
-        fnpol0 = fits.getval(fname, 'NPOLFILE')
+        fnpol0 = fname.getval('NPOLFILE')
         if fnpol0 == 'N/A':
             utils.remove_distortion(fname, "NPOLFILE")
             return False
@@ -161,7 +161,7 @@ def applyNpolCorr(fname, unpolcorr):
             raise IOError("NPOLFILE {0} not found".format(fnpol0))
         try:
             # get NPOLEXT kw from first extension header
-            fnpol1 = fits.getval(fname, 'NPOLEXT', ext=1)
+            fnpol1 = fname.getval('NPOLEXT', ext=1)
             fnpol1 = fileutil.osfn(fnpol1)
             if fnpol1 and fileutil.findFile(fnpol1):
                 if fnpol0 != fnpol1:
@@ -194,7 +194,7 @@ def isOldStyleDGEO(fname, dgname):
     # checks if the file defined in a NPOLFILE kw is a full size
     # (old style) image
 
-    sci_hdr = fits.getheader(fname, ext=1)
+    sci_hdr = fname.getheader(ext=1)
     dgeo_hdr = fits.getheader(dgname, ext=1)
     sci_naxis1 = sci_hdr['NAXIS1']
     sci_naxis2 = sci_hdr['NAXIS2']
@@ -238,7 +238,7 @@ def apply_d2im_correction(fname, d2imcorr):
         return False
     # get D2IMFILE kw from primary header
     try:
-        fd2im0 = fits.getval(fname, 'D2IMFILE')
+        fd2im0 = fname.getval('D2IMFILE')
     except KeyError:
         logger.info("D2IMFILE keyword is missing - D2IM correction will not be applied.")
         return False
@@ -252,7 +252,7 @@ def apply_d2im_correction(fname, d2imcorr):
         raise IOError(message)
     try:
         # get D2IMEXT kw from first extension header
-        fd2imext = fits.getval(fname, 'D2IMEXT', ext=1)
+        fd2imext = fname.getval('D2IMEXT', ext=1)
 
     except KeyError:
         # the case of D2IMFILE kw present in primary header but D2IMEXT missing

--- a/stwcs/updatewcs/utils.py
+++ b/stwcs/updatewcs/utils.py
@@ -7,6 +7,9 @@ logger = logging.getLogger("stwcs.updatewcs.utils")
 
 def get_file(input):
     """Return FITSObject object for input file which matches user input"""
+    if isinstance(input, FITSObject):
+        return input
+
     if isinstance(input, str):
         obj = FileObject(input)
     elif isinstance(input, fits.HDUList):
@@ -348,11 +351,11 @@ def remove_distortion(fname, dist_keyword):
     else:
         raise AttributeError("Unrecognized distortion keyword "
                              "{0} when attempting to remove distortion".format(dist_keyword))
-    ext_mapping = altwcs.mapFitsExt2HDUListInd(fname, "SCI").values()
     if isinstance(fname, FITSObject):
         f = fname.open(mode='update')
     else:
         f = fits.open(fname, mode="update")
+    ext_mapping = altwcs.mapFitsExt2HDUListInd(f, "SCI").values()
 
     for hdu in ext_mapping:
         for kw in keywords:
@@ -360,7 +363,7 @@ def remove_distortion(fname, dist_keyword):
                 del f[hdu].header[kw]
             except KeyError:
                 pass
-    ext_mapping = list(altwcs.mapFitsExt2HDUListInd(fname, extname).values())
+    ext_mapping = list(altwcs.mapFitsExt2HDUListInd(f, extname).values())
     ext_mapping.sort()
     for hdu in ext_mapping[::-1]:
         del f[hdu]


### PR DESCRIPTION
These changes address issue #67 .  

This was done by implementing a new set of classes which define a common API for working with the inputs regardless of whether they are filenames or HDUList objects.  All inputs are converted to these objects and used throughout updatewcs.  Should HDUList objects be provided as inputs, this code assumes that the user will take all responsibility for any file I/O necessary upon completing updatewcs.  