### PR TITLE
Update XML parsing, update to MASTTEST server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 
 - Allow ``updatewcs`` to be called with ``HDUList`` objects as input. [#80]
 
+- Update the XML parser for the astrometry database and switch the default to use
+  the MAST TEST server which is publicly accessible. [#74]
+
 
 1.4.2(2018-08-07)
 -----------------

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -29,7 +29,7 @@ atexit.register(logging.shutdown)
 warnings.filterwarnings("ignore", message="^Some non-standard WCS keywords were excluded:", module="astropy.wcs")
 
 def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
-              checkfiles=True, verbose=False, use_db=True):
+              checkfiles=True, verbose=False, use_db=True, update_db=False):
     """
 
     Updates HST science files with the best available calibration information.
@@ -55,25 +55,28 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
 
     Parameters
     ----------
-    input: a python list of file names or a string (wild card
+    input : a python list of file names or a string (wild card
              characters allowed) input files may be in fits, geis or
              waiver fits format
-    vacorr: boolean
+    vacorr : boolean
               If True, vecocity aberration correction will be applied
-    tddcorr: boolean
+    tddcorr : boolean
              If True, time dependent distortion correction will be applied
-    npolcorr: boolean
+    npolcorr : boolean
               If True, a Lookup table distortion will be applied
-    d2imcorr: boolean
+    d2imcorr : boolean
               If True, detector to image correction will be applied
-    checkfiles: boolean
+    checkfiles : boolean
               If True, the format of the input files will be checked,
               geis and waiver fits files will be converted to MEF format.
               Default value is True for standalone mode.
-    use_db: boolean
+    use_db : boolean
               If True, attempt to add astrometric solutions from the
               MAST astrometry database.
               Default value is True.
+    update_db : boolean
+              If True, attempt to write solution to astrometry database
+              Default value is False
     """
     if not verbose:
         logger.setLevel(100)
@@ -140,6 +143,9 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
             # Add any new astrometry solutions available from
             #  an accessible astrometry web-service
             astrometry.updateObs(f)
+            if update_db:
+                # This method will be a no-op if the observation is already in the dB
+                astrometry.updateDatabase(f)
 
         if toclose:
             f.close()

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -172,7 +172,7 @@ class AstrometryDB(object):
             # Attach new unique hdrlets to file...
             logger.info("Updating {} with:".format(observationID))
             for h in headerlets:
-                newhdrname = headerlets[h][0].header['wcsname']
+                newhdrname = headerlets[h][0].header['hdrname']
                 if newhdrname in hdrnames:
                     continue  # do not add duplicate hdrlets
                 # Add solution as an alternate WCS

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -191,7 +191,7 @@ class AstrometryDB(object):
             # Attach new unique hdrlets to file...
             logger.info("Updating {} with:".format(observationID))
             for h in headerlets:
-                newhdrname = headerlets[h][0].header['hdrname']
+                newhdrname = headerlets[h][0].header['wcsname']
                 if newhdrname in hdrnames:
                     continue  # do not add duplicate hdrlets
                 # Add solution as an alternate WCS


### PR DESCRIPTION
The astrometry database underwent some revision which slightly changed the information which gets returned upon requesting a new WCS for an observation.  This revision, however, caused the original implementation of the results parser to fail.  The changes here look for the new solutions and related information about them from the returned XML in a more general manner avoiding the previous problems with a pre-defined structure which was used in the original implementation.  

The changes here also include a switch of the default server from DEV to TEST, where the TEST server is available publicly, thereby allowing anyone to start getting any available new WCS solutions. 