### PR TITLE
Fix Deprecation Warnings

### DIFF
--- a/stwcs/distortion/utils.py
+++ b/stwcs/distortion/utils.py
@@ -53,9 +53,10 @@ def output_wcs(list_of_wcsobj, ref_wcs=None, owcs=None, undistort=True):
 
     tanpix = outwcs.wcs.s2p(fra_dec, 0)['pixcrd']
 
-    outwcs._naxis1 = int(np.ceil(tanpix[:, 0].max() - tanpix[:, 0].min()))
-    outwcs._naxis2 = int(np.ceil(tanpix[:, 1].max() - tanpix[:, 1].min()))
-    crpix = np.array([outwcs._naxis1 / 2., outwcs._naxis2 / 2.], dtype=np.float64)
+    _naxis1 = int(np.ceil(tanpix[:, 0].max() - tanpix[:, 0].min()))
+    _naxis2 = int(np.ceil(tanpix[:, 1].max() - tanpix[:, 1].min()))
+    outwcs.pixel_shape = (_naxis1, _naxis2)
+    crpix = np.array([_naxis1 / 2., _naxis2 / 2.], dtype=np.float64)
     outwcs.wcs.crpix = crpix
     outwcs.wcs.set()
     tanpix = outwcs.wcs.s2p(fra_dec, 0)['pixcrd']

--- a/stwcs/tests/test_headerlet.py
+++ b/stwcs/tests/test_headerlet.py
@@ -63,7 +63,7 @@ class TestCreateHeaderlet(object):
         extensions in the science file
         """
         hlet = headerlet.create_headerlet(self.comp_file, hdrname='hdr1')
-        hlet.writeto(self.headerlet_name, clobber=True)
+        hlet.writeto(self.headerlet_name, overwrite=True)
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [1, 4], [("SIPWCS", 1), ("SIPWCS", 2)],
                                         verbose=True)[0])
@@ -76,7 +76,7 @@ class TestCreateHeaderlet(object):
         hlet = headerlet.create_headerlet(self.comp_file,
                                           sciext=[('SCI', 1), ('SCI', 2)],
                                           hdrname='hdr1')
-        hlet.writeto(self.headerlet_name, clobber=True)
+        hlet.writeto(self.headerlet_name, overwrite=True)
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [1, 4], [("SIPWCS", 1), ("SIPWCS", 2)],
                                         verbose=True)[0])
@@ -89,7 +89,7 @@ class TestCreateHeaderlet(object):
         hlet = headerlet.create_headerlet(self.comp_file,
                                           sciext=[1, 4],
                                           hdrname='hdr1')
-        hlet.writeto(self.headerlet_name, clobber=True)
+        hlet.writeto(self.headerlet_name, overwrite=True)
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [1, 4], [("SIPWCS", 1), ("SIPWCS", 2)],
                                         verbose=True)[0])
@@ -102,7 +102,7 @@ class TestCreateHeaderlet(object):
         hlet = headerlet.create_headerlet(self.simple_file,
                                           sciext=0,
                                           hdrname='hdr1')
-        hlet.writeto(self.headerlet_name, clobber=True)
+        hlet.writeto(self.headerlet_name, overwrite=True)
         assert(wcsdiff.is_wcs_identical(self.simple_file, self.headerlet_name,
                                         [0], [1], verbose=True)[0])
 
@@ -125,7 +125,7 @@ class TestCreateHeaderlet(object):
         hlet = headerlet.create_headerlet(self.comp_file,
                                           sciext=4,
                                           hdrname='hdr1')
-        hlet.writeto(self.headerlet_name, clobber=True)
+        hlet.writeto(self.headerlet_name, overwrite=True)
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [4], [1], verbose=True)[0])
 
@@ -224,7 +224,7 @@ class TestApplyHeaderlet:
         hlet['SIPWCS', 2].header['CRPIX1'] = 2
         hlet['SIPWCS', 2].header['CRPIX2'] = 2
         hlet.apply_as_primary(self.comp_file)
-        hlet.writeto(self.headerlet_name, clobber=True)
+        hlet.writeto(self.headerlet_name, overwrite=True)
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [('SCI', 1), ('SCI', 2)],
                                         [("SIPWCS", 1), ("SIPWCS", 2)],
@@ -242,7 +242,7 @@ class TestApplyHeaderlet:
     def test_apply_as_alternate_method(self):
         hlet = headerlet.create_headerlet(self.comp_file, hdrname='test1')
         hlet.apply_as_alternate(self.comp_file, wcskey='K', wcsname='KK')
-        hlet.writeto(self.headerlet_name, clobber=True)
+        hlet.writeto(self.headerlet_name, overwrite=True)
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [('SCI', 1), ('SCI', 2)],
                                         [("SIPWCS", 1), ("SIPWCS", 2)],
@@ -279,7 +279,7 @@ class TestRestoreHeaderlet:
 
         updatewcs.updatewcs(acs_file)
         self.sci_file = acs_file
-        
+
     def test_restore_headerlet(self):
         hdrname = 'test1'
         hlet = headerlet.create_headerlet(self.sci_file, hdrname='test1')
@@ -288,13 +288,13 @@ class TestRestoreHeaderlet:
         hlet['sipwcs',1].header['crval2'] += 1./3600.
         hlet['sipwcs',2].header['crval1'] += 1./3600.
         hlet['sipwcs',2].header['crval2'] += 1./3600.
-        hlet.writeto(self.headerlet_name, clobber=True)
-        
+        hlet.writeto(self.headerlet_name, overwrite=True)
+
         headerlet.attach_headerlet(self.sci_file, self.headerlet_name)
-        hlet_extn = headerlet.find_headerlet_HDUs(self.sci_file, 
+        hlet_extn = headerlet.find_headerlet_HDUs(self.sci_file,
                                                   hdrname=hdrname)[0]
         headerlet.restore_from_headerlet(self.sci_file, hdrext=hlet_extn)
-        
+
         assert(wcsdiff.is_wcs_identical(self.sci_file, self.headerlet_name,
                                         [('SCI', 1), ('SCI', 2)],
                                         [("SIPWCS", 1), ("SIPWCS", 2)],

--- a/stwcs/tests/test_updatewcs.py
+++ b/stwcs/tests/test_updatewcs.py
@@ -119,8 +119,7 @@ class TestStwcs(object):
             outwcs.wcs.cd,
             np.array([[1.2787045268089949e-05, 5.4215042082174661e-06],
                       [5.4215042082174661e-06, -1.2787045268089949e-05]]))
-        assert(outwcs._naxis1 == 4214)
-        assert(outwcs._naxis2 == 4237)
+        assert outwcs.pixel_shape == (4214, 4237)
 
     def test_repeate(self):
         # make sure repeated runs of updatewcs do not change the WCS.

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -2427,10 +2427,7 @@ class Headerlet(fits.HDUList):
         """
         if not destim or not hdrname:
             self.hverify()
-        if ASTROPY_13_MIN:
-            self.writeto(fname, overwrite=clobber)
-        else:
-            self.writeto(fname, clobber=clobber)
+        self.writeto(fname, overwrite=clobber)
 
     def _del_dest_WCS(self, dest, ext=None):
         """

--- a/stwcs/wcsutil/hstwcs.py
+++ b/stwcs/wcsutil/hstwcs.py
@@ -167,19 +167,21 @@ class HSTWCS(WCS):
 
     @property
     def naxis1(self):
-        return self._naxis1
+        return self.pixel_shape[0]
 
     @naxis1.setter
     def naxis1(self, value):
-        self._naxis1 = value
+        val1 = self.pixel_shape[1] if self.pixel_shape is not None else 0
+        self.pixel_shape = (value, val1)
 
     @property
     def naxis2(self):
-        return self._naxis2
+        return self.pixel_shape[1]
 
     @naxis2.setter
     def naxis2(self, value):
-        self._naxis2 = value
+        val0 = self.pixel_shape[0] if self.pixel_shape is not None else 0
+        self.pixel_shape = (val0, value)
 
     def readIDCCoeffs(self, header):
         """

--- a/stwcs/wcsutil/mosaic.py
+++ b/stwcs/wcsutil/mosaic.py
@@ -70,9 +70,9 @@ def vmosaic(fnames, outwcs=None, ref_wcs=None, ext=None, extname=None, undistort
         else:
             outwcs = utils.output_wcs(wcsobjects, undistort=undistort)
     if plot:
-        outc = np.array([[0., 0], [outwcs._naxis1, 0],
-                         [outwcs._naxis1, outwcs._naxis2],
-                         [0, outwcs._naxis2], [0, 0]])
+        outc = np.array([[0., 0], [outwcs.pixel_shape[0], 0],
+                         [outwcs.pixel_shape[0], outwcs.pixel_shape[1]],
+                         [0, outwcs.pixel_shape[1]], [0, 0]])
         plt.plot(outc[:, 0], outc[:, 1])
     for wobj in wcsobjects:
         outcorners = outwcs.wcs_world2pix(wobj.calc_footprint(), 1)


### PR DESCRIPTION
This replaces `wcs._naxis1(2)` with `wcs.pixel_shape` and fits `clobber` with `overwrite`.