### PR TITLE
updatewcs should work with HDUList objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ env:
         - ASTROPY_VERSION=development
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/conda-dev'
-        - CONDA_DEPENDENCIES='pytest drizzlepac'
+        - CONDA_DEPENDENCIES='pytest'
+        - TOOLS_GIT='git+https://github.com/spacetelescope/stsci.tools.git'
+        - PIP_DEPENDENCIES="$TOOLS_GIT"
+
 
     matrix:
         - SETUP_CMD='egg_info'
@@ -38,7 +41,7 @@ matrix:
         # build sphinx documentation with warnings
         - python: 3.6
           env: SETUP_CMD='build_sphinx'
-               PIP_DEPENDENCIES='sphinx-automodapi sphinx_rtd_theme'
+               PIP_DEPENDENCIES='sphinx-automodapi sphinx_rtd_theme git+https://github.com/spacetelescope/stsci.tools.git'
 
     allow_failures:
         # Do a PEP8 test with pycodestyle

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 
 - Filter out expected warnings from tests. [#78]
 
+- Allow ``updatewcs`` to be called with ``HDUList`` objects as input. [#80]
+
+
 1.4.2(2018-08-07)
 -----------------
 

--- a/stwcs/tests/test_updatewcs.py
+++ b/stwcs/tests/test_updatewcs.py
@@ -168,6 +168,35 @@ def test_remove_npol_distortion():
     assert w4.cpdis2 is None
 
 
+def test_remove_npol_distortion_hdulist():
+    acs_orig_file = get_filepath('j94f05bgq_flt.fits')
+    current_dir = os.path.abspath(os.path.curdir)
+    acs_file = get_filepath('j94f05bgq_flt.fits', current_dir)
+    idctab = get_filepath('postsm4_idc.fits')
+    npol_file = get_filepath('qbu16424j_npl.fits')
+    d2imfile = get_filepath('new_wfc_d2i.fits ')
+
+    try:
+        os.remove(acs_file)
+    except OSError:
+        pass
+
+    shutil.copyfile(acs_orig_file, acs_file)
+    hdul = fits.open(acs_file, mode='update')
+    hdul[0].header["IDCTAB"] = idctab
+    hdul[0].header["NPOLFILE"] = npol_file
+    hdul[0].header["D2IMFILE"] = d2imfile
+
+    updatewcs.updatewcs(hdul)
+    hdul[0].header["NPOLFILE"] = "N/A"
+    updatewcs.updatewcs(hdul)
+    w1 = HSTWCS(hdul, ext=("SCI", 1))
+    w4 = HSTWCS(hdul, ext=("SCI", 2))
+    assert w1.cpdis1 is None
+    assert w4.cpdis2 is None
+    hdul.close()
+
+
 def test_remove_d2im_distortion():
     acs_orig_file = get_filepath('j94f05bgq_flt.fits')
     current_dir = os.path.abspath(os.path.curdir)
@@ -211,6 +240,10 @@ def test_missing_idctab():
     with pytest.raises(IOError):
         updatewcs.updatewcs(acs_file)
 
+    fobj = fits.open(acs_file)
+    with pytest.raises(IOError):
+        updatewcs.updatewcs(fobj)
+
 
 def test_missing_npolfile():
     """ Tests that an IOError is raised if an NPOLFILE file is not found on disk."""
@@ -229,6 +262,10 @@ def test_missing_npolfile():
     with pytest.raises(IOError):
         updatewcs.updatewcs(acs_file)
 
+    fobj = fits.open(acs_file)
+    with pytest.raises(IOError):
+        updatewcs.updatewcs(fobj)
+
 
 def test_missing_d2imfile():
     """ Tests that an IOError is raised if a D2IMFILE file is not found on disk."""
@@ -246,6 +283,10 @@ def test_missing_d2imfile():
     fits.setval(acs_file, keyword="D2IMFILE", value="missing_d2i.fits")
     with pytest.raises(IOError):
         updatewcs.updatewcs(acs_file)
+
+    fobj = fits.open(acs_file)
+    with pytest.raises(IOError):
+        updatewcs.updatewcs(fobj)
 
 
 def test_found_idctab():
@@ -266,6 +307,12 @@ def test_found_idctab():
     fits.setval(acs_file, ext=0, keyword="D2IMFILE", value=d2imfile)
     fits.setval(acs_file, keyword="IDCTAB", value="N/A")
     corrections = apply_corrections.setCorrections(acs_file)
+    assert('MakeWCS' not in corrections)
+    assert('TDDCor' not in corrections)
+    assert('CompSIP' not in corrections)
+
+    fobj = fits.open(acs_file)
+    corrections = apply_corrections.setCorrections(fobj)
     assert('MakeWCS' not in corrections)
     assert('TDDCor' not in corrections)
     assert('CompSIP' not in corrections)

--- a/stwcs/tests/test_updatewcs.py
+++ b/stwcs/tests/test_updatewcs.py
@@ -344,7 +344,8 @@ def test_apply_d2im():
     fits.setval(fname, ext=0, keyword="IDCTAB", value='N/A')
     fits.setval(fname, ext=0, keyword="NPOLFILE", value='N/A')
     # If D2IMEXT does not exist, the correction should be applied
-    assert appc.apply_d2im_correction(fname, d2imcorr=True)
+    fileobj = fits.open(fname, mode='update')
+    assert appc.apply_d2im_correction(fileobj, d2imcorr=True)
     updatewcs.updatewcs(fname)
 
     # Test the case when D2IMFILE == D2IMEXT

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -151,18 +151,15 @@ class AstrometryDB(object):
         if not self.perform_step:
             return
 
-        # Parse observation name
-        obspath, obsroot = os.path.split(obsname)
-        # use `obspath` for location of output files,
-        #    if anything gets written out
+        obsroot = obsname[0].header.get('rootname', None)
         observationID = obsroot.split('_')[:1][0]
         logger.info("Updating astrometry for {}".format(observationID))
         #
         # apply to file...
-        fileobj = pf.open(obsname, mode='update')
+        #fileobj = pf.open(obsname, mode='update')
 
         # take inventory of what hdrlets are already appended to this file
-        hdrnames = headerlet.get_headerlet_kw_names(fileobj, 'hdrname')
+        hdrnames = headerlet.get_headerlet_kw_names(obsname, 'hdrname')
 
         headerlets, best_solution_id = self.getObservation(observationID)
         if headerlets is None:
@@ -180,7 +177,7 @@ class AstrometryDB(object):
             logger.warning(" Updating database with initial WCS {}".
                            format(observationID))
             hlet_buffer = BytesIO()
-            hlet_new = headerlet.create_headerlet(fileobj)
+            hlet_new = headerlet.create_headerlet(obsname)
             newhdrname = hlet_new[0].header['hdrname']
             hlet_new.writeto(hlet_buffer)
 
@@ -200,18 +197,18 @@ class AstrometryDB(object):
                 try:
                     if best_solution_id and newhdrname == best_solution_id:
                         # replace primary WCS with this solution
-                        headerlets[h].apply_as_primary(fileobj)
+                        headerlets[h].apply_as_primary(obsname)
                         logger.info('Replacing primary WCS with')
                         logger.info('\tHeaderlet with HDRNAME={}'.format(
                                      newhdrname))
                     else:
                         logger.info("\tHeaderlet with HDRNAME={}".format(
                                     newhdrname))
-                        headerlets[h].attach_to_file(fileobj)
+                        headerlets[h].attach_to_file(obsname)
                 except ValueError:
                     pass
 
-        fileobj.close()
+        #fileobj.close()
 
     def findObservation(self, observationID):
         """Find whether there are any entries in the AstrometryDB for

--- a/stwcs/updatewcs/utils.py
+++ b/stwcs/updatewcs/utils.py
@@ -244,7 +244,8 @@ def build_d2imname(fobj, d2imfile=None):
 
 
 def remove_distortion(fname, dist_keyword):
-    logger.info("Removing distortion {0} from file {0}".format(dist_keyword, fname))
+    logger.info("Removing distortion {0} from file {0}".format(dist_keyword,
+                                                               fname[0].header['rootname']))
     from ..wcsutil import altwcs
     if dist_keyword == "NPOLFILE":
         extname = "WCSDVARR"
@@ -256,15 +257,15 @@ def remove_distortion(fname, dist_keyword):
         raise AttributeError("Unrecognized distortion keyword "
                              "{0} when attempting to remove distortion".format(dist_keyword))
     ext_mapping = altwcs.mapFitsExt2HDUListInd(fname, "SCI").values()
-    f = fits.open(fname, mode="update")
+    #f = fits.open(fname, mode="update")
     for hdu in ext_mapping:
         for kw in keywords:
             try:
-                del f[hdu].header[kw]
+                del fname[hdu].header[kw]
             except KeyError:
                 pass
     ext_mapping = list(altwcs.mapFitsExt2HDUListInd(fname, extname).values())
     ext_mapping.sort()
     for hdu in ext_mapping[::-1]:
-        del f[hdu]
-    f.close()
+        del fname[hdu]
+    #f.close()

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -1,5 +1,5 @@
 import string
-import warnings
+
 import numpy as np
 from astropy import wcs as pywcs
 from astropy.io import fits
@@ -7,8 +7,6 @@ from stsci.tools import fileutil as fu
 
 from astropy import log
 default_log_level = log.getEffectiveLevel()
-
-warnings.filterwarnings("ignore", message="^Some non-standard WCS keywords were excluded:", module="astropy.wcs.wcs")
 
 
 __all__ = ["archiveWCS", "available_wcskeys", "convertAltWCS", "deleteWCS", "next_wcskey",
@@ -692,11 +690,11 @@ def getKeyFromName(header, wcsname):
 
 def pc2cd(hdr, key=' '):
     """
-    Convert a CD matrix to a CD matrix.
+    Convert a PC matrix to a CD matrix.
 
     WCSLIB (and PyWCS) recognizes CD keywords as input
     but converts them and works internally with the PC matrix.
-    to_header() returns the PC matrix even if the i nput was a
+    to_header() returns the PC matrix even if the input was a
     CD matrix. To keep input and output consistent we check
     for has_cd and convert the PC back to CD.
 

--- a/stwcs/wcsutil/hstwcs.py
+++ b/stwcs/wcsutil/hstwcs.py
@@ -58,7 +58,7 @@ class NoConvergence(Exception):
     """
     An error class used to report non-convergence and/or divergence of
     numerical methods. It is used to report errors in the iterative solution
-    used by the :py:meth:`~stwcs.hstwcs.HSTWCS.all_world2pix`\ .
+    used by the :py:meth:`~stwcs.hstwcs.HSTWCS.all_world2pix`.
 
     Attributes
     ----------
@@ -67,11 +67,11 @@ class NoConvergence(Exception):
         Best solution achieved by the method.
 
     accuracy : float
-        Accuracy of the :py:attr:`best_solution`\ .
+        Accuracy of the :py:attr:`best_solution`.
 
     niter : int
         Number of iterations performed by the numerical method to compute
-        :py:attr:`best_solution`\ .
+        :py:attr:`best_solution`.
 
     divergent : None, numpy.array
         Indices of the points in :py:attr:`best_solution` array for which the
@@ -470,8 +470,8 @@ class HSTWCS(WCS):
 
     def all_world2pix(self, *args, **kwargs):
         """
-        all_world2pix(*arg, accuracy=1.0e-4, maxiter=20, adaptive=False, \
-detect_divergence=True, quiet=False)
+        all_world2pix(*arg, accuracy=1.0e-4, maxiter=20, adaptive=False,
+        detect_divergence=True, quiet=False)
 
         Performs full inverse transformation using iterative solution
         on full forward transformation with complete distortion model.
@@ -481,7 +481,7 @@ detect_divergence=True, quiet=False)
         accuracy : float, optional (Default = 1.0e-4)
             Required accuracy of the solution. Iteration terminates when the
             correction to the solution found during the previous iteration
-            is smaller (in the sence of the L2 norm) than `accuracy`\ .
+            is smaller (in the sence of the L2 norm) than `accuracy` .
 
         maxiter : int, optional (Default = 20)
             Maximum number of iterations allowed to reach the solution.
@@ -503,21 +503,21 @@ detect_divergence=True, quiet=False)
                additional iterations may be needed (this depends mostly on the
                characteristics of the geometric distortions for a given
                instrument). In this situation it may be
-               advantageous to set `adaptive` = `True`\ in which
+               advantageous to set `adaptive` = `True` in which
                case :py:meth:`all_world2pix` will continue iterating *only* over
                the points that have not yet converged to the required
                accuracy. However, for the HST's ACS/WFC detector, which has
                the strongest distortions of all HST instruments, testing has
-               shown that enabling this option would lead to a about 10-30\%
+               shown that enabling this option would lead to a about 10-30 %
                penalty in computational time (depending on specifics of the
                image, geometric distortions, and number of input points to be
                converted). Therefore, for HST instruments,
-               it is recommended to set `adaptive` = `False`\ . The only
+               it is recommended to set `adaptive` = `False` . The only
                danger in getting this setting wrong will be a performance
                penalty.
 
             .. note::
-               When `detect_divergence` is `True`\ , :py:meth:`all_world2pix` \
+               When `detect_divergence` is `True` , :py:meth:`all_world2pix`
                will automatically switch to the adaptive algorithm once
                divergence has been detected.
 
@@ -533,7 +533,7 @@ detect_divergence=True, quiet=False)
             solution will diverge regardless of the `tolerance` or `maxiter`
             settings.
 
-            When `detect_divergence` is `False`\ , these divergent points
+            When `detect_divergence` is `False` , these divergent points
             will be detected as not having achieved the required accuracy
             (without further details). In addition, if `adaptive` is `False`
             then the algorithm will not know that the solution (for specific
@@ -541,33 +541,33 @@ detect_divergence=True, quiet=False)
             "improve" diverging solutions. This may result in NaN or Inf
             values in the return results (in addition to a performance
             penalties). Even when `detect_divergence` is
-            `False`\ , :py:meth:`all_world2pix`\ , at the end of the iterative
+            `False` , :py:meth:`all_world2pix` , at the end of the iterative
             process, will identify invalid results (NaN or Inf) as "diverging"
             solutions and will raise :py:class:`NoConvergence` unless
-            the `quiet` parameter is set to `True`\ .
+            the `quiet` parameter is set to `True` .
 
-            When `detect_divergence` is `True`\ , :py:meth:`all_world2pix` will
+            When `detect_divergence` is `True`, :py:meth:`all_world2pix` will
             detect points for
             which current correction to the coordinates is larger than
             the correction applied during the previous iteration **if** the
-            requested accuracy **has not yet been achieved**\ . In this case,
+            requested accuracy **has not yet been achieved**. In this case,
             if `adaptive` is `True`, these points will be excluded from
             further iterations and if `adaptive`
-            is `False`\ , :py:meth:`all_world2pix` will automatically
+            is `False`, :py:meth:`all_world2pix` will automatically
             switch to the adaptive algorithm.
 
             .. note::
                When accuracy has been achieved, small increases in
                current corrections may be possible due to rounding errors
-               (when `adaptive` is `False`\ ) and such increases
+               (when `adaptive` is `False` ) and such increases
                will be ignored.
 
             .. note::
-               Setting `detect_divergence` to `True` will incurr about 5-10\%
+               Setting `detect_divergence` to `True` will incurr about 5-10%
                performance penalty (in our testing on ACS/WFC images).
                Because the benefits of enabling this feature outweigh
                the small performance penalty, it is recommended to set
-               `detect_divergence` to `True`\ , unless extensive testing
+               `detect_divergence` to `True`, unless extensive testing
                of the distortion models for images from specific
                instruments show a good stability of the numerical method
                for a wide range of coordinates (even outside the image
@@ -605,7 +605,7 @@ detect_divergence=True, quiet=False)
         of the method of consecutive approximations and therefore it is
         highly efficient (>30x) when *all* data points that need to be
         converted from sky coordinates to image coordinates are passed at
-        *once*\ . Therefore, it is advisable, whenever possible, to pass
+        *once*. Therefore, it is advisable, whenever possible, to pass
         as input a long array of all points that need to be converted
         to :py:meth:`all_world2pix` instead of calling :py:meth:`all_world2pix`
         for each data point. Also see the note to the `adaptive` parameter.
@@ -635,21 +635,21 @@ detect_divergence=True, quiet=False)
         [[ 1.00000233  0.99999997]
          [ 2.00000232  0.99999997]
          [ 3.00000233  0.99999998]]
-        >>> xy = w.all_world2pix(radec,1, maxiter=3, accuracy=1.0e-10, \
+        >>> xy = w.all_world2pix(radec,1, maxiter=3, accuracy=1.0e-10,
 quiet=False)
-        NoConvergence: 'HSTWCS.all_world2pix' failed to converge to requested \
+        NoConvergence: 'HSTWCS.all_world2pix' failed to converge to requested
 accuracy after 3 iterations.
 
         >>>
         Now try to use some diverging data:
-        >>> divradec = w.all_pix2world([[1.0,1.0],[10000.0,50000.0],\
+        >>> divradec = w.all_pix2world([[1.0,1.0],[10000.0,50000.0],
 [3.0,1.0]],1); print(divradec)
         [[  5.52645241 -72.05171776]
          [  7.15979392 -70.81405561]
          [  5.52653313 -72.05170814]]
 
         >>> try:
-        >>>   xy = w.all_world2pix(divradec,1, maxiter=20, accuracy=1.0e-4, \
+        >>>   xy = w.all_world2pix(divradec,1, maxiter=20, accuracy=1.0e-4,
 adaptive=False, detect_divergence=True, quiet=False)
         >>> except stwcs.wcsutil.hstwcs.NoConvergence as e:
         >>>   print("Indices of diverging points: {}".format(e.divergent))
@@ -675,8 +675,8 @@ adaptive=False, detect_divergence=True, quiet=False)
         After 5 iterations, the solution is diverging at least for one input point.
 
         >>> try:
-        >>>   xy = w.all_world2pix(divradec,1, maxiter=20, accuracy=1.0e-4, \
-adaptive=False, detect_divergence=False, quiet=False)
+        >>>   xy = w.all_world2pix(divradec,1, maxiter=20, accuracy=1.0e-4,
+              adaptive=False, detect_divergence=False, quiet=False)
         >>> except stwcs.wcsutil.hstwcs.NoConvergence as e:
         >>>   print("Indices of diverging points: {}".format(e.divergent))
         >>>   print("Indices of poorly converging points: {}".format(e.failed2converge))


### PR DESCRIPTION
depends on spacetelescope/stsci.tools#86

This PR supersedes #68 and addresses #67.
It adds supports for HDUList objects as inputs to updatewcs. At the moment the files passed to updatewcs must be opened in `update` mode.