### PR TITLE
Respond gracefully to null result from database

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@
 - Update the XML parser for the astrometry database and switch the default to use
   the MAST TEST server which is publicly accessible. [#74]
 
+- Gracefully ignore when the astrometry database returns an empty result for
+  an image. [#84] 
+
 
 1.4.2(2018-08-07)
 -----------------

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -276,9 +276,10 @@ class AstrometryDB(object):
                 return None, None
 
         r = self.findObservation(observationID)
+        best_solution_id = None
 
         if r is None or self.new_observation:
-            return r, None
+            return r, best_solution_id
         else:
             # Now, interpret return value for observation into separate
             # headerlets to be appended to observation
@@ -304,6 +305,8 @@ class AstrometryDB(object):
             for solution_info in solutions:
                 solutionID = solution_info['solutionID']
                 wcsName = solution_info['wcsName']
+                if solutionID is None:
+                    continue
                 # Translate bestSolutionID into wcsName, if one is specified
                 if best_solution_id and best_solution_id == solutionID:
                     best_solution_id = wcsName


### PR DESCRIPTION
The astrometry database can (as uncovered in testing) return query results for an image where all fields have a value of 'None', effectively a NULL result with no WCS.  This small set of changes protects against that as gracefully as possible, instead of throwing an Exception that would impede the pipeline when used. 