### PR TITLE
Fix reapply bestwcs

### DIFF
--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -187,11 +187,16 @@ class AstrometryDB(object):
         # This needs to be separate logic in order to work with images which have already
         # been updated with solutions from the database, and we are simply resetting.
         if best_solution_id:
-            for h in headerlets:
-                wcsname = headerlets[h][0].header['wcsname']
+            # get full list of all headerlet extensions now in the file
+            hdrlet_extns = headerlet.get_extname_extver_list(obsname, 'hdrlet')
+
+            for h in hdrlet_extns:
+                hdrlet = obsname[h].headerlet
+                wcsname = hdrlet[0].header['wcsname']
                 if wcsname == best_solution_id:
                     # replace primary WCS with this solution
-                    headerlets[h].apply_as_primary(obsname)
+                    hdrlet.init_attrs()
+                    hdrlet.apply_as_primary(obsname, attach=False)
                     logger.info('Replacing primary WCS with')
                     logger.info('\tHeaderlet with WCSNAME={}'.format(
                                  newname))

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -184,6 +184,8 @@ class AstrometryDB(object):
                     pass
         # Once all the new headerlet solutions have been added as new extensions
         # Apply the best solution, if one was specified, as primary WCS
+        # This needs to be separate logic in order to work with images which have already
+        # been updated with solutions from the database, and we are simply resetting.
         if best_solution_id:
             for h in headerlets:
                 wcsname = headerlets[h][0].header['wcsname']

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -177,20 +177,23 @@ class AstrometryDB(object):
                     continue  # do not add duplicate hdrlets
                 # Add solution as an alternate WCS
                 try:
-                    if best_solution_id and newname == best_solution_id:
-                        # replace primary WCS with this solution
-                        headerlets[h].apply_as_primary(obsname)
-                        logger.info('Replacing primary WCS with')
-                        logger.info('\tHeaderlet with WCSNAME={}'.format(
-                                     newname))
-                        break
-                    else:
-                        logger.info("\tHeaderlet with WCSNAME={}".format(
-                                    newname))
-                        headerlets[h].attach_to_file(obsname)
+                    logger.info("\tHeaderlet with WCSNAME={}".format(
+                                newname))
+                    headerlets[h].attach_to_file(obsname)
                 except ValueError:
                     pass
-
+        # Once all the new headerlet solutions have been added as new extensions
+        # Apply the best solution, if one was specified, as primary WCS
+        if best_solution_id:
+            for h in headerlets:
+                wcsname = headerlets[h][0].header['wcsname']
+                if wcsname == best_solution_id:
+                    # replace primary WCS with this solution
+                    headerlets[h].apply_as_primary(obsname)
+                    logger.info('Replacing primary WCS with')
+                    logger.info('\tHeaderlet with WCSNAME={}'.format(
+                                 newname))
+                    break
 
     def findObservation(self, observationID):
         """Find whether there are any entries in the AstrometryDB for


### PR DESCRIPTION
The logic for applying the best WCS solution works perfectly well for pipeline calibration use where no previous solutions from the database have been added as extensions to the exposure yet.  However, upon re-running updatewcs (which people reprocessing their data to align to various catalogs will need to do), the 'best' WCS solution did NOT get applied to avoid adding duplicate extensions with the same WCS solution.

This change splits the logic so that it checks for the presence of each solution from the database, and appends it to the file if it is new THEN after that operation completes, it applies the 'best' solution as the primary WCS using the full list headerlet extensions.  This insures that the solution which gets applied has already been appended as an extension (archived), while working seamlessly with any previously appended solutions. 

Pipeline use will NOT be affected by this change, but it will make life easier for users as they work with data retrieved from the archive. 