### PR TITLE
Ignore pipeline default solutions as best a priori WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.5.1 (Unreleased)
 ------------------
 
+- Do not apply pipeline-default WCSs from astrometry database as new WCS. [#96]
+
 - Improve Travis test matrices to include testing with public and dev
   versions of dependencies. [#87]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
+1.5.2 (Unreleased)
+------------------
+- Do not apply pipeline-default WCSs from astrometry database as new WCS. [#96]
+
+
 1.5.1 (Unreleased)
 ------------------
-
-- Do not apply pipeline-default WCSs from astrometry database as new WCS. [#96]
 
 - Improve Travis test matrices to include testing with public and dev
   versions of dependencies. [#87]

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -158,6 +158,10 @@ class AstrometryDB(object):
         wcsnames = headerlet.get_headerlet_kw_names(obsname, 'wcsname')
 
         headerlets, best_solution_id = self.getObservation(observationID)
+        # Determine whether best_solution_id is simply the pipeline default solution
+        if len(best_solution_id.split('-')) == 1: 
+            best_solution_id = None
+        
         if headerlets is None:
             logger.warning("Problems getting solutions from database")
             logger.warning(" NO Updates performed for {}".format(

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -159,9 +159,9 @@ class AstrometryDB(object):
 
         headerlets, best_solution_id = self.getObservation(observationID)
         # Determine whether best_solution_id is simply the pipeline default solution
-        if len(best_solution_id.split('-')) == 1: 
+        if best_solution_id and len(best_solution_id.split('-')) == 1: 
             best_solution_id = None
-        
+
         if headerlets is None:
             logger.warning("Problems getting solutions from database")
             logger.warning(" NO Updates performed for {}".format(


### PR DESCRIPTION
New WCS solutions from the astrometry database includes pipeline default WCS solutions as a record of the calibration of the astrometry of the observation.  Unfortunately, sometimes these are the only solutions for an observation in the database, and therefore they get flagged as the 'best' solution for the exposure.  This, however, will overwrite the distortion correction being applied by 'updatewcs' which most likely is what the user really wants.  

This revision allows all the unique solutions from the astrometry database to still be appended as headerlet extensions to the exposure, but does NOT apply as the primary WCS any pipeline default solution (either OPUS or IDC_* WCS) from the database. 