### PR TITLE
Re-direct log messages to stdout as well as log file

### DIFF
--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -32,11 +32,18 @@ from io import BytesIO
 from lxml import etree
 
 from stwcs.wcsutil import headerlet
-from stwcs.updatewcs import utils
 
 import logging
 logger = logging.getLogger('stwcs.updatewcs.astrometry_utils')
-logger.addHandler(logging.StreamHandler(sys.stdout))
+if len(logger.handlers) > 0:
+    for handler in logger.handlers:
+          # add the handlers to the logger
+          # makes sure no duplicate handlers are added
+        if not isinstance(handler, logging.StreamHandler):
+            logger.addHandler(logging.StreamHandler(sys.stdout))
+else:
+    logger.addHandler(logging.StreamHandler(sys.stdout))
+
 
 atexit.register(logging.shutdown)
 

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -38,8 +38,10 @@ logger = logging.getLogger('stwcs.updatewcs.astrometry_utils')
 if len(logger.handlers) > 0:
     for handler in logger.handlers:
           # add the handlers to the logger
-          # makes sure no duplicate handlers are added
-        if not isinstance(handler, logging.StreamHandler):
+          # makes sure no duplicate stdout handlers are added
+        if not isinstance(handler, logging.StreamHandler) or \
+            (isinstance(handler, logging.StreamHandler) and \
+             handler.stream is not sys.stdout):
             logger.addHandler(logging.StreamHandler(sys.stdout))
 else:
     logger.addHandler(logging.StreamHandler(sys.stdout))

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -23,6 +23,7 @@ ASTROMETRY_STEP_CONTROL - String specifying whether or not to perform the
                           Valid Values: "ON", "On", "on", "OFF", "Off", "off"
                           If not set, default value is "ON".
 """
+import sys
 import os
 import atexit
 
@@ -35,6 +36,7 @@ from stwcs.updatewcs import utils
 
 import logging
 logger = logging.getLogger('stwcs.updatewcs.astrometry_utils')
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 atexit.register(logging.shutdown)
 


### PR DESCRIPTION
This relative simple and minor change allows the messages generated when updating WCS from the astrometry database to be sent to stdout whether a log file is generated or not by updatewcs through the 'verbose' parameter.  

The few additional messages generated here will avoid future problems where users were unaware that their active WCS was updated with a solution from the database.  