### PR TITLE
Correct code that archives WCSs with different distortion models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Add ``stdout`` to logging handlers. [#108]
 
+- Correct the logic for replacing headerlets with one which has a different 
+  distortion model. [#109]
+
 
 1.5.2 (2019-08-26)
 ------------------

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -203,7 +203,7 @@ class AstrometryDB(object):
                 if wcsname == best_solution_id:
                     # replace primary WCS with this solution
                     hdrlet.init_attrs()
-                    hdrlet.apply_as_primary(obsname, attach=False)
+                    hdrlet.apply_as_primary(obsname, attach=False, force=True)
                     logger.info('Replacing primary WCS with')
                     logger.info('\tHeaderlet with WCSNAME={}'.format(
                                  newname))

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1977,12 +1977,16 @@ class Headerlet(fits.HDUList):
                 altwcs.archiveWCS(fobj, ext=sciext_list, wcskey=nextkey,
                                   wcsname=priwcs_name)
             else:
-
                 for hname in altwcs.wcsnames(fobj, ext=target_ext).values():
                     if hname != 'OPUS' and hname not in hdrlet_extnames:
-                        # get HeaderletHDU for alternate WCS as well
+                        nextkey = altwcs.next_wcskey(fobj, ext=target_ext)
+                        # Archive original WCS as alternate WCS with its own key
+                        altwcs.archiveWCS(fobj, ext=sciext_list, wcskey=nextkey,
+                                  wcsname=hname)
+
+                        # create HeaderletHDU for alternate WCS now
                         alt_hlet = create_headerlet(fobj, sciext=sciext_list,
-                                                    wcsname=hname, wcskey=wcskey,
+                                                    wcsname=hname, wcskey=nextkey,
                                                     hdrname=hname, sipname=None,
                                                     npolfile=None, d2imfile=None,
                                                     author=None, descrip=None, history=None,


### PR DESCRIPTION
This change addresses problems in the headerlet code when replacing one headerlet/WCS with another which uses a different distortion model.  