### PR TITLE
Add logic to ignore updating header with the same WCS from the database

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.5.4 (Unreleased)
 ------------------
 
+- Prevent same WCS from being updated from astrometry database headerlet. [#111]
+
 - Revise how headerlets are applied as primary WCS [#122]
 
 
@@ -9,7 +11,7 @@
 
 - Add ``stdout`` to logging handlers. [#108]
 
-- Correct the logic for replacing headerlets with one which has a different 
+- Correct the logic for replacing headerlets with one which has a different
   distortion model. [#109]
 
 

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -163,6 +163,10 @@ class AstrometryDB(object):
         # take inventory of what hdrlets are already appended to this file
         wcsnames = headerlet.get_headerlet_kw_names(obsname, 'wcsname')
 
+        # Get all the WCS solutions available from the astrometry database
+        # for this observation, along with what was flagged as the 'best'
+        # solution.  The 'best' solution should be the one that aligns the
+        # observation closest to the GAIA frame.
         headerlets, best_solution_id = self.getObservation(observationID)
         if headerlets is None:
             logger.warning("Problems getting solutions from database")
@@ -282,6 +286,13 @@ class AstrometryDB(object):
             Dictionary containing all solutions found for exposure in the
             form of headerlets labelled by the name given to the solution in
             the database.
+            
+        best_solution_id : str
+            WCSNAME of the WCS solution flagged as 'best' in the astrometry
+            database for the observation.  The 'best' solution should be the 
+            one that aligns the observation as close to the GAIA frame as 
+            possible.
+            
         """
         if not self.perform_step:
             return None, None

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -188,11 +188,13 @@ class AstrometryDB(object):
                     headerlets[h].attach_to_file(obsname)
                 except ValueError:
                     pass
+        # Obtain the current primary WCS name
+        current_wcsname = obsname[('sci', 1)].header['wcsname']
         # Once all the new headerlet solutions have been added as new extensions
         # Apply the best solution, if one was specified, as primary WCS
         # This needs to be separate logic in order to work with images which have already
         # been updated with solutions from the database, and we are simply resetting.
-        if best_solution_id:
+        if best_solution_id and best_solution_id != current_wcsname:
             # get full list of all headerlet extensions now in the file
             hdrlet_extns = headerlet.get_extname_extver_list(obsname, 'hdrlet')
 

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -8,6 +8,18 @@ solutions for HST data and provide those solutions in a manner
 that would not require getting entirely new images from the archive
 when only the WCS information has been updated.
 
+NOTE ::
+  This module defines a FileHandler for the logging in the current
+  working directory for the user when this module first gets imported.
+  If that directory is removed later by the user, it will cause an
+  Exception when performing headerlet operations later.
+
+  The file handler can be identified using::
+
+    rl = logging.getLogger('stwcs.wcsutil.headerlet')
+    rl.handlers
+    del rl.handlers[-1]  # if FileHandler was the last one, remove it
+  
 """
 import os
 import sys


### PR DESCRIPTION
This pull request allows solutions from the astrometry database to be appended to an observation, but if the 'best' solution is identical to the currently active WCS, it does NOT update from the headerlet.  

We have found during extended testing that some of the solutions in the astrometry database are not complete and use of these solutions as an active WCS can cause WCS-related code to thrown an exception.  This simple change not only makes the code more reasonable it what it applies, but further protects pipeline use of the code from throwing an exception in limited use cases.   