### PR TITLE
Revise apply_as_primary to use update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 1.5.4 (Unreleased)
 ------------------
 
+- Revise how headerlets are applied as primary WCS [#122]
+
+
 1.5.3 (2019-09-23)
 ------------------
 

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1161,6 +1161,7 @@ def apply_headerlet_as_primary(filename, hdrlet, attach=True, archive=True,
     for fname, h in zip(filename, hdrlet):
         print("Applying {0} as Primary WCS to {1}".format(h, fname))
         hlet = Headerlet.fromfile(h, logging=logging, logmode=logmode)
+        print("HDRNAME: {}".format(hlet.hdrname))
         hlet.apply_as_primary(fname, attach=attach, archive=archive,
                               force=force)
 
@@ -1904,7 +1905,7 @@ class Headerlet(fits.HDUList):
             raise ValueError("Destination name does not match headerlet"
                              "Observation {0} cannot be updated with"
                              "headerlet {1}".format((fname, self.hdrname)))
-
+        
         # Check to see whether the distortion model in the destination
         # matches the distortion model in the headerlet being applied
 
@@ -2061,7 +2062,7 @@ class Headerlet(fits.HDUList):
                     priwcs[('WCSDVARR', 2)].header['EXTVER'] = self[('SIPWCS', i)].header['DP2.EXTVER']
                     numnpol = 2
 
-            fobj[target_ext].header.extend(priwcs[0].header)
+            fobj[target_ext].header.update(priwcs[0].header)
             if sipwcs.cpdis1:
                 whdu = priwcs[('WCSDVARR', (i - 1) * numnpol + 1)].copy()
                 whdu.ver = int(self[('SIPWCS', i)].header['DP1.EXTVER'])

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1161,7 +1161,6 @@ def apply_headerlet_as_primary(filename, hdrlet, attach=True, archive=True,
     for fname, h in zip(filename, hdrlet):
         print("Applying {0} as Primary WCS to {1}".format(h, fname))
         hlet = Headerlet.fromfile(h, logging=logging, logmode=logmode)
-        print("HDRNAME: {}".format(hlet.hdrname))
         hlet.apply_as_primary(fname, attach=attach, archive=archive,
                               force=force)
 


### PR DESCRIPTION
Using 'pdb' to track how the 'apply_as_primary()' method worked, it turned out that the WCS keywords from the headerlet were being copied into the science file science extension header using 'header.extend'.  This creates copies of the header keywords at the end of the header resulting in multiple versions of some WCS keywords like the 'wcsname' keyword (for example).  More crucially, it was not allowing new keywords, like 'hdrname', to end up in the output science header.  

This update changes that code to use 'header.update' instead which results in all the new keywords from the headerlet showing up in the science header while also getting the new values from the headerlet into the science header.  

This would address #121 based on interactive tests using 'jc0593z1q'.