### PR TITLE
Add and preserve existing WCS comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ docs/_build
 # Packages/installer info
 *.egg
 *.egg-info
+.eggs/
 dist
 build
 eggs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,13 +5,11 @@
 
 - Revise how headerlets are applied as primary WCS [#122]
 
-<<<<<<< HEAD
 - Primary WCS keywords no longer contain trailing spaces which, in the past,
   lead to duplicate keywords in image headers. [#131]
-=======
+
 - Add comments to WCS keywords for ``IDC*``, ``OCX``, ``OCY``, and alternate
   WCS. [#127]
->>>>>>> Add and preserve existing WCS comments
 
 
 1.5.3 (2019-09-23)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,13 @@
 
 - Revise how headerlets are applied as primary WCS [#122]
 
+<<<<<<< HEAD
 - Primary WCS keywords no longer contain trailing spaces which, in the past,
   lead to duplicate keywords in image headers. [#131]
+=======
+- Add comments to WCS keywords for ``IDC*``, ``OCX``, ``OCY``, and alternate
+  WCS. [#127]
+>>>>>>> Add and preserve existing WCS comments
 
 
 1.5.3 (2019-09-23)

--- a/stwcs/updatewcs/corrections.py
+++ b/stwcs/updatewcs/corrections.py
@@ -70,7 +70,7 @@ class TDDCorr(object):
         ext_wcs.idcmodel.ocx = copy.deepcopy(ext_wcs.idcmodel.cx)
         ext_wcs.idcmodel.ocy = copy.deepcopy(ext_wcs.idcmodel.cy)
 
-        ocxy_comment = "linear term without scale from IDCTAB file"
+        ocxy_comment = "original linear term from IDCTAB"
 
         newkw = {'TDDALPHA': None,
                  'TDDBETA': None,

--- a/stwcs/updatewcs/corrections.py
+++ b/stwcs/updatewcs/corrections.py
@@ -70,14 +70,20 @@ class TDDCorr(object):
         ext_wcs.idcmodel.ocx = copy.deepcopy(ext_wcs.idcmodel.cx)
         ext_wcs.idcmodel.ocy = copy.deepcopy(ext_wcs.idcmodel.cy)
 
-        newkw = {'TDDALPHA': None, 'TDDBETA': None,
-                 'OCX10': ext_wcs.idcmodel.ocx[1, 0],
-                 'OCX11': ext_wcs.idcmodel.ocx[1, 1],
-                 'OCY10': ext_wcs.idcmodel.ocy[1, 0],
-                 'OCY11': ext_wcs.idcmodel.ocy[1, 1],
-                 'TDD_CTA': None, 'TDD_CTB': None,
-                 'TDD_CYA': None, 'TDD_CYB': None,
-                 'TDD_CXA': None, 'TDD_CXB': None
+        ocxy_comment = "linear term without scale from IDCTAB file"
+
+        newkw = {'TDDALPHA': None,
+                 'TDDBETA': None,
+                 'TDD_CTA': None,
+                 'TDD_CTB': None,
+                 'TDD_CYA': None,
+                 'TDD_CYB': None,
+                 'TDD_CXA': None,
+                 'TDD_CXB': None,
+                 'OCX10': (ext_wcs.idcmodel.ocx[1, 0], ocxy_comment),
+                 'OCX11': (ext_wcs.idcmodel.ocx[1, 1], ocxy_comment),
+                 'OCY10': (ext_wcs.idcmodel.ocy[1, 0], ocxy_comment),
+                 'OCY11': (ext_wcs.idcmodel.ocy[1, 1], ocxy_comment),
                  }
 
         if ext_wcs.idcmodel.refpix['skew_coeffs'] is not None and \
@@ -111,9 +117,29 @@ class TDDCorr(object):
             ext_wcs.idcmodel.refpix['TDDBETA'] = beta
             ref_wcs.idcmodel.refpix['TDDALPHA'] = alpha
             ref_wcs.idcmodel.refpix['TDDBETA'] = beta
-            newkw.update({'TDDALPHA': alpha, 'TDDBETA': beta} )
+            newkw.update({'TDDALPHA': alpha,
+                          'TDDBETA': beta} )
+
+        # add keyword comments
+        newkw['TDDALPHA'] = (newkw['TDDALPHA'],
+                             "time-dependent y-skew offset (pre-2014 IDCTAB)")
+        newkw['TDDBETA'] = (newkw['TDDBETA'],
+                            "time-dependent y-skew rate (pre-2014 IDCTAB)")
+        newkw['TDD_CXB'] = (newkw['TDD_CXB'],
+                            "time-dependent x-scale rate (>2015 IDCTAB)")
+        newkw['TDD_CYB'] = (newkw['TDD_CYB'],
+                            "time-dependent y-scale rate (>2015 IDCTAB)")
+        newkw['TDD_CTA'] = (newkw['TDD_CTA'],
+                            "time-dependent x-skew rate (>2015 IDCTAB)")
+        newkw['TDD_CTB'] = (newkw['TDD_CTB'],
+                            "time-dependent y-skew rate (>2015 IDCTAB)")
+        newkw['TDD_CXA'] = (newkw['TDD_CXA'],
+                            "time-dependent x-skew offset (2014 IDCTAB)")
+        newkw['TDD_CYA'] = (newkw['TDD_CYA'],
+                            "time-dependent y-skew offset (2014 IDCTAB)")
 
         return newkw
+
     updateWCS = classmethod(updateWCS)
 
     def apply_tdd2idc2015(cls, hwcs):
@@ -267,11 +293,16 @@ class VACorr(object):
             crval = np.array([crval0, crval1])
             ext_wcs.wcs.crval = crval
             ext_wcs.wcs.set()
-        else:
-            pass
-        kw2update = {'CD1_1': ext_wcs.wcs.cd[0, 0], 'CD1_2': ext_wcs.wcs.cd[0, 1],
-                     'CD2_1': ext_wcs.wcs.cd[1, 0], 'CD2_2': ext_wcs.wcs.cd[1, 1],
-                     'CRVAL1': ext_wcs.wcs.crval[0], 'CRVAL2': ext_wcs.wcs.crval[1]}
+
+        kw2update = {
+            'CD1_1': ext_wcs.wcs.cd[0, 0],
+            'CD1_2': ext_wcs.wcs.cd[0, 1],
+            'CD2_1': ext_wcs.wcs.cd[1, 0],
+            'CD2_2': ext_wcs.wcs.cd[1, 1],
+            'CRVAL1': ext_wcs.wcs.crval[0],
+            'CRVAL2': ext_wcs.wcs.crval[1]
+        }
+
         return kw2update
 
     updateWCS = classmethod(updateWCS)
@@ -300,8 +331,8 @@ class CompSIP(object):
             logger.info("IDC model not found, SIP coefficient will not be computed.")
             return kw2update
         order = ext_wcs.idcmodel.norder
-        kw2update['A_ORDER'] = order
-        kw2update['B_ORDER'] = order
+        kw2update['A_ORDER'] = order, 'SIP polynomial order, axis 1, detector to sky'
+        kw2update['B_ORDER'] = order, 'SIP polynomial order, axis 2, detector to sky'
         # pscale = ext_wcs.idcmodel.refpix['PSCALE']
 
         cx = ext_wcs.idcmodel.cx
@@ -311,6 +342,7 @@ class CompSIP(object):
         imatr = linalg.inv(matr)
         akeys1 = np.zeros((order + 1, order + 1), dtype=np.float64)
         bkeys1 = np.zeros((order + 1, order + 1), dtype=np.float64)
+        sip_comment = 'SIP distortion coefficient'
         for n in range(order + 1):
             for m in range(order + 1):
                 if n >= m and n >= 2:
@@ -320,8 +352,8 @@ class CompSIP(object):
                     bkeys1[m, n - m] = sipval[1]
                     Akey = "A_%d_%d" % (m, n - m)
                     Bkey = "B_%d_%d" % (m, n - m)
-                    kw2update[Akey] = sipval[0, 0] * ext_wcs.binned
-                    kw2update[Bkey] = sipval[1, 0] * ext_wcs.binned
+                    kw2update[Akey] = sipval[0, 0] * ext_wcs.binned, sip_comment
+                    kw2update[Bkey] = sipval[1, 0] * ext_wcs.binned, sip_comment
         kw2update['CTYPE1'] = 'RA---TAN-SIP'
         kw2update['CTYPE2'] = 'DEC--TAN-SIP'
         return kw2update

--- a/stwcs/updatewcs/npol.py
+++ b/stwcs/updatewcs/npol.py
@@ -248,62 +248,40 @@ class NPOLCorr(object):
                 nplextver = ext.header['EXTVER']
             except KeyError:
                 continue
+
             nplccdchip = cls.get_ccdchip(npl, extname=nplextname, extver=nplextver)
             if nplextname == npl_extname and nplccdchip == ccdchip:
                 npol_header = ext.header
                 break
-            else:
-                continue
+
         npl.close()
 
         naxis = npl[1].header['NAXIS']
         ccdchip = nplextname  # npol_header['CCDCHIP']
 
-        kw = {'NAXIS': 'Size of the axis',
-              'CDELT': 'Coordinate increment along axis',
-              'CRPIX': 'Coordinate system reference pixel',
-              'CRVAL': 'Coordinate system value at reference pixel',
-              }
-
-        kw_comm1 = {}
-        kw_val1 = {}
-        for key in kw.keys():
-            for i in range(1, naxis + 1):
-                si = str(i)
-                kw_comm1[key + si] = kw[key]
+        cdl = [
+            ('XTENSION', 'IMAGE', 'Image extension'),
+            ('BITPIX', -32, 'number of bits per data pixel'),
+            ('NAXIS', naxis, 'Number of data axes'),
+            ('EXTNAME', 'WCSDVARR', 'WCS distortion array'),
+            ('EXTVER', wdvarr_ver, 'Distortion array version number'),
+            ('PCOUNT', 0, 'number of parameters'),
+            ('GCOUNT', 1, 'number of groups'),
+            ('CCDCHIP', ccdchip),
+        ]
 
         for i in range(1, naxis + 1):
-            si = str(i)
-            kw_val1['NAXIS' + si] = npol_header.get('NAXIS' + si)
-            kw_val1['CDELT' + si] = npol_header.get('CDELT' + si, 1.0) * \
-                sciheader.get('LTM' + si + '_' + si, 1)
-            kw_val1['CRPIX' + si] = npol_header.get('CRPIX' + si, 0.0)
-            kw_val1['CRVAL' + si] = (npol_header.get('CRVAL' + si, 0.0) -
-                                     sciheader.get('LTV' + str(i), 0))
+            cdl.append((f'NAXIS{i:d}', npol_header.get(f'NAXIS{i:d}'),
+                        f"length of data axis {i:d}"))
+            cdl.append((f'CDELT{i:d}', npol_header.get(f'CDELT{i:d}', 1.0) *
+                        sciheader.get(f'LTM{i:d}_{i:d}', 1),
+                        "Coordinate increment at reference point"))
+            cdl.append((f'CRPIX{i:d}', npol_header.get(f'CRPIX{i:d}', 0.0),
+                        "Pixel coordinate of reference point"))
+            cdl.append((f'CRVAL{i:d}', npol_header.get(f'CRVAL{i:d}', 0.0) -
+                        sciheader.get(f'LTV{i:d}', 0),
+                        "Coordinate value at reference point"))
 
-        kw_comm0 = {'XTENSION': 'Image extension',
-                    'BITPIX': 'IEEE floating point',
-                    'NAXIS': 'Number of axes',
-                    'EXTNAME': 'WCS distortion array',
-                    'EXTVER': 'Distortion array version number',
-                    'PCOUNT': 'Special data area of size 0',
-                    'GCOUNT': 'One data group',
-                    }
-
-        kw_val0 = {'XTENSION': 'IMAGE',
-                   'BITPIX': -32,
-                   'NAXIS': naxis,
-                   'EXTNAME': 'WCSDVARR',
-                   'EXTVER': wdvarr_ver,
-                   'PCOUNT': 0,
-                   'GCOUNT': 1,
-                   'CCDCHIP': ccdchip,
-                   }
-        cdl = []
-        for key in kw_comm0.keys():
-            cdl.append((key, kw_val0[key], kw_comm0[key]))
-        for key in kw_comm1.keys():
-            cdl.append((key, kw_val1[key], kw_comm1[key]))
         # Now add keywords from NPOLFILE header to document source of calibration
         # include all keywords after and including 'FILENAME' from header
         start_indx = -1

--- a/stwcs/wcsutil/hstwcs.py
+++ b/stwcs/wcsutil/hstwcs.py
@@ -454,10 +454,10 @@ class HSTWCS(WCS):
     def _idc2hdr(self):
         # save some of the idc coefficients
         coeffs = [
-            ('ocx10', 'linear term without scale from IDCTAB file'),
-            ('ocx11', 'linear term without scale from IDCTAB file'),
-            ('ocy10', 'linear term without scale from IDCTAB file'),
-            ('ocy11', 'linear term without scale from IDCTAB file'),
+            ('ocx10', 'original linear term from IDCTAB'),
+            ('ocx11', 'original linear term from IDCTAB'),
+            ('ocy10', 'original linear term from IDCTAB'),
+            ('ocy11', 'original linear term from IDCTAB'),
             ('idcscale', 'pixel scale from the IDCTAB reference file'),
         ]
         cards = []
@@ -945,7 +945,7 @@ adaptive=False, detect_divergence=True, quiet=False)
     def _updatehdr(self, ext_hdr):
         # kw2add : OCX10, OCX11, OCY10, OCY11
         # record the model in the header for use by pydrizzle
-        ocx_comment = "linear term without scale from IDCTAB file"
+        ocx_comment = "original linear term from IDCTAB"
         ext_hdr['OCX10'] = self.idcmodel.cx[1, 0], ocx_comment
         ext_hdr['OCX11'] = self.idcmodel.cx[1, 1], ocx_comment
         ext_hdr['OCY10'] = self.idcmodel.cy[1, 0], ocx_comment

--- a/stwcs/wcsutil/hstwcs.py
+++ b/stwcs/wcsutil/hstwcs.py
@@ -453,15 +453,21 @@ class HSTWCS(WCS):
 
     def _idc2hdr(self):
         # save some of the idc coefficients
-        coeffs = ['ocx10', 'ocx11', 'ocy10', 'ocy11', 'idcscale']
+        coeffs = [
+            ('ocx10', 'linear term without scale from IDCTAB file'),
+            ('ocx11', 'linear term without scale from IDCTAB file'),
+            ('ocy10', 'linear term without scale from IDCTAB file'),
+            ('ocy11', 'linear term without scale from IDCTAB file'),
+            ('idcscale', 'pixel scale from the IDCTAB reference file'),
+        ]
         cards = []
-        for c in coeffs:
+        for k, c in coeffs:
             try:
-                val = self.__getattribute__(c)
+                val = self.__getattribute__(k)
             except AttributeError:
                 continue
             if val:
-                cards.append(fits.Card(keyword=c, value=val))
+                cards.append(fits.Card(keyword=k, value=val, comment=c))
         return cards
 
     def pc2cd(self):
@@ -939,16 +945,23 @@ adaptive=False, detect_divergence=True, quiet=False)
     def _updatehdr(self, ext_hdr):
         # kw2add : OCX10, OCX11, OCY10, OCY11
         # record the model in the header for use by pydrizzle
-        ext_hdr['OCX10'] = self.idcmodel.cx[1, 0]
-        ext_hdr['OCX11'] = self.idcmodel.cx[1, 1]
-        ext_hdr['OCY10'] = self.idcmodel.cy[1, 0]
-        ext_hdr['OCY11'] = self.idcmodel.cy[1, 1]
-        ext_hdr['IDCSCALE'] = self.idcmodel.refpix['PSCALE']
-        ext_hdr['IDCTHETA'] = self.idcmodel.refpix['THETA']
-        ext_hdr['IDCXREF'] = self.idcmodel.refpix['XREF']
-        ext_hdr['IDCYREF'] = self.idcmodel.refpix['YREF']
-        ext_hdr['IDCV2REF'] = self.idcmodel.refpix['V2REF']
-        ext_hdr['IDCV3REF'] = self.idcmodel.refpix['V3REF']
+        ocx_comment = "linear term without scale from IDCTAB file"
+        ext_hdr['OCX10'] = self.idcmodel.cx[1, 0], ocx_comment
+        ext_hdr['OCX11'] = self.idcmodel.cx[1, 1], ocx_comment
+        ext_hdr['OCY10'] = self.idcmodel.cy[1, 0], ocx_comment
+        ext_hdr['OCY11'] = self.idcmodel.cy[1, 1], ocx_comment
+        ext_hdr['IDCSCALE'] = (self.idcmodel.refpix['PSCALE'],
+                               "pixel scale from the IDCTAB reference file")
+        ext_hdr['IDCTHETA'] = (self.idcmodel.refpix['THETA'],
+                               "orientation of detector's Y-axis w.r.t. V3 axis")
+        ext_hdr['IDCXREF'] = (self.idcmodel.refpix['XREF'],
+                              "reference pixel location in X")
+        ext_hdr['IDCYREF'] = (self.idcmodel.refpix['YREF'],
+                              "reference pixel location in Y")
+        ext_hdr['IDCV2REF'] = (self.idcmodel.refpix['V2REF'],
+                               "reference pixel's V2 position")
+        ext_hdr['IDCV3REF'] = (self.idcmodel.refpix['V3REF'],
+                               "reference pixel's V3 position")
 
     def printwcs(self):
         """


### PR DESCRIPTION
This PR fixes issues with WCS keyword comments disappearing when archiving a WCS. Also, this PR adds new comments to `OCX*`, `OCY*`, `IDC*`, `CD*`, and `SIP` coefficients.