### PR TITLE
Do not add trailing spaces to WCS header keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,13 +3,16 @@
 
 - Revise how headerlets are applied as primary WCS [#122]
 
+- Primary WCS keywords no longer contain trailing spaces which, in the past,
+  lead to duplicate keywords in image headers. [#131]
+
 
 1.5.3 (2019-09-23)
 ------------------
 
 - Add ``stdout`` to logging handlers. [#108]
 
-- Correct the logic for replacing headerlets with one which has a different 
+- Correct the logic for replacing headerlets with one which has a different
   distortion model. [#109]
 
 

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -128,6 +128,8 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
         wkey = wcskey
         wname = wcsname
     log.setLevel('WARNING')
+
+    wkey = wkey.strip()
     for e in ext:
         hdr = _getheader(f, e)
         w = pywcs.WCS(hdr, f)
@@ -440,6 +442,8 @@ def _restore(fobj, ukey, fromextnum,
     if w.wcs.has_cd():
         hwcs = pc2cd(hwcs, key=ukey)
 
+    ukey = ukey.strip()
+
     for i in range(1, w.naxis + 1):
         hwcs['CTYPE{0}{1}'.format(i, ukey)] = ctype['CTYPE{0}'.format(i)]
 
@@ -548,6 +552,7 @@ def convertAltWCS(fobj, ext, oldkey=" ", newkey=' '):
     hdr: `astropy.io.fits.Header`
         header object with keywords renamed from oldkey to newkey
     """
+    newkey = newkey.strip()
     hdr = readAltWCS(fobj, ext, wcskey=oldkey)
     if hdr is None:
         return None
@@ -698,6 +703,7 @@ def pc2cd(hdr, key=' '):
     hdr: `astropy.io.fits.Header`
 
     """
+    key = key.strip()
     for c in ['1_1', '1_2', '2_1', '2_2']:
         try:
             val = hdr['PC{0}{1}'.format(c, key)]

--- a/stwcs/wcsutil/mosaic.py
+++ b/stwcs/wcsutil/mosaic.py
@@ -87,24 +87,24 @@ def vmosaic(fnames, outwcs=None, ref_wcs=None, ext=None, extname=None, undistort
 
 def updatehdr(fname, wcsobj, wkey, wcsname, ext=1, clobber=False):
     hdr = fits.getheader(fname, ext=ext)
-    all_keys = list(string.ascii_uppercase)
-    if wkey.upper() not in all_keys:
-        raise KeyError("wkey must be one character: A-Z")
+    wkey_hdr = wkey.upper().strip()
+    if len(wkey) != 1 or wkey_hdr not in string.ascii_uppercase:
+        raise KeyError("'wkey' must be one character: A-Z or space (' ')")
+
     if wkey not in altwcs.available_wcskeys(hdr):
         if not clobber:
-            raise ValueError("wkey {0} is already in use."
-                             "Use clobber=True to overwrite it or"
+            raise ValueError("'wkey' '{:.1s}' is already in use. "
+                             "Use clobber=True to overwrite it or "
                              "specify a different key.".format(wkey))
         else:
             altwcs.deleteWCS(fname, ext=ext, wcskey='V')
-    f = fits.open(fname, mode='update')
 
+    f = fits.open(fname, mode='update')
     hwcs = wcs2header(wcsobj)
-    wcsnamekey = 'WCSNAME' + wkey
+    wcsnamekey = 'WCSNAME' + wkey_hdr
     f[ext].header[wcsnamekey] = wcsname
     for k in hwcs:
-        f[ext].header[k[: 7] + wkey] = hwcs[k]
-
+        f[ext].header[k[: 7] + wkey_hdr] = hwcs[k]
     f.close()
 
 


### PR DESCRIPTION
This PR strips trailing spaces from WCS header keywords before corresponding `astropy.io.fits.Header` cards are created. This should allow using `stwcs` with older versions of `astropy` not containing https://github.com/astropy/astropy/pull/10482 fix.

Closes #125