### PR TITLE
Fix a crash in tweakreg due to recent code changes

### DIFF
--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -77,9 +77,6 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
     # Interpret input 'ext' value to get list of extensions to process
     ext = _buildExtlist(f, ext)
 
-    if wcskey == ' ' and wcsname == ' ':
-        raise KeyError("Either wcskey or wcsname should be specified")
-
     if wcsname == ' ':
         try:
             wcsname = readAltWCS(f, ext[0], wcskey=" ")['WCSNAME']


### PR DESCRIPTION
`tweakreg` in `drizzlepac` started crashing after https://github.com/spacetelescope/stwcs/pull/132 depending on the values of `wcsname` keyword and `reusename`. This is due to the following change:

https://github.com/spacetelescope/stwcs/pull/132/files#diff-516dcd10bb4c104d97362626d506e981L75-L76

and https://github.com/mcara/stwcs/blob/98b2007defc5be07295676fb31d6eb89e61fe1b8/stwcs/wcsutil/altwcs.py#L62-L66

The reason this code was not crashing before was that it could never execute since `wcsname` and `wcskey` could not evaluate to false (default values for these parameters are a blank space `' '`  which does not evaluate to `False`).

This effectively means that the check:
```python
    if wcskey == ' ' and wcsname == ' ':
        raise KeyError("Either wcskey or wcsname should be specified")
```
can be safely removed.