### PR TITLE
Do not archive non-altwcs specific keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,14 @@
 - Add comments to WCS keywords for ``IDC*``, ``OCX``, ``OCY``, and alternate
   WCS. [#127]
 
+- WCS keywords that are not specific to an alternate WCS (such as ``MJDREF``)
+  are no longer archived. [#141]
+
+- Fix a bug in ``_restore()`` due to which ``TDDALPHA`` and ``TDDBETA`` were
+  not reset to ``0.0`` when restoring wrom the ``'OPUS'`` WCS with key ``'O'``. [#141]
+
+- Increased reliability of detecting alternate WCS in image headers. [#141]
+
 
 1.5.3 (2019-09-23)
 ------------------

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -490,8 +490,7 @@ def wcs_from_key(fobj, ext, from_key=' ', to_key=None):
         When ``to_key`` is `None`, the returned header describes a WCS with the
         same key as the one read in using ``from_key``. A space character or
         a single ASCII letter indicates the key to be used for the returned
-        WCS (see ``from_key`` for details) and it **must** be different from
-        ``from_key`` parameter.
+        WCS (see ``from_key`` for details).
 
     Returns
     -------
@@ -511,11 +510,6 @@ def wcs_from_key(fobj, ext, from_key=' ', to_key=None):
     elif len(to_key) != 1 or to_key.strip() not in string.ascii_uppercase:
         raise ValueError(
             "Parameter 'to_key' must be a character - one of 'A'-'Z' or ' '."
-        )
-
-    elif to_key == from_key:
-        raise ValueError(
-            "When parameter 'to_key' is not None, it must be different from 'from_key'."
         )
 
     if isinstance(fobj, str):


### PR DESCRIPTION
This PR fixes #82 (increased reliability of detecting alternate WCS in the header), fixes #133, fixes #139, fixes #140 

In addition, it consolidates code that is used in numerous other functions into one single function `_read_alt_wcs()`. This improves code maintenance.