### PR TITLE
Shorten D2IM and CPDIS keyword comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-1.5.4 (Unreleased)
+1.6.0 (Unreleased)
 ------------------
 
 - Prevent same WCS from being updated from astrometry database headerlet. [#111]
@@ -18,6 +18,8 @@
   not reset to ``0.0`` when restoring wrom the ``'OPUS'`` WCS with key ``'O'``. [#141]
 
 - Increased reliability of detecting alternate WCS in image headers. [#141]
+
+- Abbreviated comments for ``D2IM``, ``CPDIS`` lookup table distortions. [#142]
 
 - Add comments to ``WCSNAMEa`` header keywords. [#143]
 

--- a/doc/source/fits_convention_tsr/source/appendix4.rst
+++ b/doc/source/fits_convention_tsr/source/appendix4.rst
@@ -189,16 +189,16 @@ D2IMFILE corrections from the specific reference files used as examples in :ref:
  WCSNAME = 'IDC_v8q1444sj'
  CPERR1  =                  0.0 / Maximum error of NPOL correction for axis 1
  CPDIS1  = 'Lookup  '           / Prior distortion funcion type
- DP1     = 'EXTVER: 1' / Version number of WCSDVARR extension containing lookup d
- DP1     = 'NAXES: 2' / Number of independent variables in distortion function
- DP1     = 'AXIS.1: 1' / Axis number of the jth independent variable in a distort
- DP1     = 'AXIS.2: 2' / Axis number of the jth independent variable in a distort
+ DP1     = 'EXTVER: 1' / Version number of WCSDVARR extension
+ DP1     = 'NAXES: 2' / Number of independent variables in CPDIS function
+ DP1     = 'AXIS.1: 1' / Axis number of the jth variable in a CPDIS function
+ DP1     = 'AXIS.2: 2' / Axis number of the jth variable in a CPDIS function
  CPERR2  =                  0.0 / Maximum error of NPOL correction for axis 2
  CPDIS2  = 'Lookup  '           / Prior distortion funcion type
- DP2     = 'EXTVER: 2' / Version number of WCSDVARR extension containing lookup d
- DP2     = 'NAXES: 2' / Number of independent variables in distortion function
- DP2     = 'AXIS.1: 1' / Axis number of the jth independent variable in a distort
- DP2     = 'AXIS.2: 2' / Axis number of the jth independent variable in a distort
+ DP2     = 'EXTVER: 2' / Version number of WCSDVARR extension
+ DP2     = 'NAXES: 2' / Number of independent variables in CPDIS function
+ DP2     = 'AXIS.1: 1' / Axis number of the jth variable in a CPDIS function
+ DP2     = 'AXIS.2: 2' / Axis number of the jth variable in a CPDIS function
  NPOLEXT = 'jref$v971826aj_npl.fits'
 
 

--- a/doc/source/fits_convention_tsr/source/appendix4.rst
+++ b/doc/source/fits_convention_tsr/source/appendix4.rst
@@ -191,14 +191,14 @@ D2IMFILE corrections from the specific reference files used as examples in :ref:
  CPDIS1  = 'Lookup  '           / Prior distortion funcion type
  DP1     = 'EXTVER: 1' / Version number of WCSDVARR extension
  DP1     = 'NAXES: 2' / Number of independent variables in CPDIS function
- DP1     = 'AXIS.1: 1' / Axis number of the jth variable in a CPDIS function
- DP1     = 'AXIS.2: 2' / Axis number of the jth variable in a CPDIS function
+ DP1     = 'AXIS.1: 1' / Axis number of the 1st variable in a CPDIS function
+ DP1     = 'AXIS.2: 2' / Axis number of the 2nd variable in a CPDIS function
  CPERR2  =                  0.0 / Maximum error of NPOL correction for axis 2
  CPDIS2  = 'Lookup  '           / Prior distortion funcion type
  DP2     = 'EXTVER: 2' / Version number of WCSDVARR extension
  DP2     = 'NAXES: 2' / Number of independent variables in CPDIS function
- DP2     = 'AXIS.1: 1' / Axis number of the jth variable in a CPDIS function
- DP2     = 'AXIS.2: 2' / Axis number of the jth variable in a CPDIS function
+ DP2     = 'AXIS.1: 1' / Axis number of the 1st variable in a CPDIS function
+ DP2     = 'AXIS.2: 2' / Axis number of the 2nd variable in a CPDIS function
  NPOLEXT = 'jref$v971826aj_npl.fits'
 
 

--- a/doc/source/npol_tsr/source/npol_append.rst
+++ b/doc/source/npol_tsr/source/npol_append.rst
@@ -3,34 +3,34 @@ Appendix
 
 Sample WCSDVARR extension header::
 
-    XTENSION= 'IMAGE   '           / Image extension                                
-    BITPIX  =                  -32 / array data type                                
-    NAXIS   =                    2 / number of array dimensions                     
-    NAXIS1  =                   65                                                  
-    NAXIS2  =                   33                                                  
-    PCOUNT  =                    0 / number of parameters                           
-    GCOUNT  =                    1 / number of groups                               
-    EXTVER  =                    1 / Distortion array version number                
-    EXTNAME = 'WCSDVARR'           / WCS distortion array                           
-    CRVAL2  =                  0.0 / Coordinate system value at reference pixel     
-    CRPIX1  =                  0.0 / Coordinate system reference pixel              
-    CRPIX2  =                  0.0 / Coordinate system reference pixel              
-    CRVAL1  =                  0.0 / Coordinate system value at reference pixel     
-    CDELT1  =                   64 / Coordinate increment along axis                
-    CDELT2  =                   64 / Coordinate increment along axis                
+    XTENSION= 'IMAGE   '           / Image extension
+    BITPIX  =                  -32 / array data type
+    NAXIS   =                    2 / number of array dimensions
+    NAXIS1  =                   65
+    NAXIS2  =                   33
+    PCOUNT  =                    0 / number of parameters
+    GCOUNT  =                    1 / number of groups
+    EXTVER  =                    1 / Distortion array version number
+    EXTNAME = 'WCSDVARR'           / WCS distortion array
+    CRVAL2  =                  0.0 / Coordinate system value at reference pixel
+    CRPIX1  =                  0.0 / Coordinate system reference pixel
+    CRPIX2  =                  0.0 / Coordinate system reference pixel
+    CRVAL1  =                  0.0 / Coordinate system value at reference pixel
+    CDELT1  =                   64 / Coordinate increment along axis
+    CDELT2  =                   64 / Coordinate increment along axis
 
 
 Sample science extension keywords defining a lookup table distortions::
 
-    CPERROR1=                0.058602706   / Maximum error of dgeo correction for axis 1    
-    CPDIS1  = 'Lookup  '           / Prior distortion function type                  
-    DP1     = 'EXTVER: 1.0'        / Version number of WCSDVARR extension containing 
-    DP1     = 'NAXES: 2.0'         / Number of independent variables in distortion f 
-    DP1     = 'AXIS.1: 1.0'        / Axis number of the jth independent variable in 
-    DP1     = 'AXIS.2: 2.0'        / Axis number of the jth independent variable in 
-    CPERROR2=        0.072911568  / Maximum error of dgeo correction for axis 2    
-    CPDIS2  = 'Lookup  '           / Prior distortion function type                  
-    DP2     = 'EXTVER: 2.0'        / Version number of WCSDVARR extension containing 
-    DP2     = 'NAXES: 2.0'         / Number of independent variables in distortion f 
-    DP2     = 'AXIS.1: 1.0'        / Axis number of the jth independent variable in 
-    DP2     = 'AXIS.2: 2.0'        / Axis number of the jth independent variable in 
+    CPERROR1=                0.058602706   / Maximum error of dgeo correction for axis 1
+    CPDIS1  = 'Lookup  '           / Prior distortion function type
+    DP1     = 'EXTVER: 1.0'        / Version number of WCSDVARR extension
+    DP1     = 'NAXES: 2.0'         / Number of independent variables in CPDIS function
+    DP1     = 'AXIS.1: 1.0'        / Axis number of the jth variable in a CPDIS function
+    DP1     = 'AXIS.2: 2.0'        / Axis number of the jth variable in a CPDIS function
+    CPERROR2=        0.072911568  / Maximum error of dgeo correction for axis 2
+    CPDIS2  = 'Lookup  '           / Prior distortion function type
+    DP2     = 'EXTVER: 2.0'        / Version number of WCSDVARR extension
+    DP2     = 'NAXES: 2.0'         / Number of independent variables in CPDIS function
+    DP2     = 'AXIS.1: 1.0'        / Axis number of the jth variable in a CPDIS function
+    DP2     = 'AXIS.2: 2.0'        / Axis number of the jth variable in a CPDIS function

--- a/doc/source/npol_tsr/source/npol_append.rst
+++ b/doc/source/npol_tsr/source/npol_append.rst
@@ -26,11 +26,11 @@ Sample science extension keywords defining a lookup table distortions::
     CPDIS1  = 'Lookup  '           / Prior distortion function type
     DP1     = 'EXTVER: 1.0'        / Version number of WCSDVARR extension
     DP1     = 'NAXES: 2.0'         / Number of independent variables in CPDIS function
-    DP1     = 'AXIS.1: 1.0'        / Axis number of the jth variable in a CPDIS function
-    DP1     = 'AXIS.2: 2.0'        / Axis number of the jth variable in a CPDIS function
+    DP1     = 'AXIS.1: 1.0'        / Axis number of the 1st variable in a CPDIS function
+    DP1     = 'AXIS.2: 2.0'        / Axis number of the 2nd variable in a CPDIS function
     CPERROR2=        0.072911568  / Maximum error of dgeo correction for axis 2
     CPDIS2  = 'Lookup  '           / Prior distortion function type
     DP2     = 'EXTVER: 2.0'        / Version number of WCSDVARR extension
     DP2     = 'NAXES: 2.0'         / Number of independent variables in CPDIS function
-    DP2     = 'AXIS.1: 1.0'        / Axis number of the jth variable in a CPDIS function
-    DP2     = 'AXIS.2: 2.0'        / Axis number of the jth variable in a CPDIS function
+    DP2     = 'AXIS.1: 1.0'        / Axis number of the 1st variable in a CPDIS function
+    DP2     = 'AXIS.2: 2.0'        / Axis number of the 2nd variable in a CPDIS function

--- a/stwcs/updatewcs/det2im.py
+++ b/stwcs/updatewcs/det2im.py
@@ -117,13 +117,15 @@ class DET2IMCorr(object):
         """
         j = 1 if d2im_extname == 'DX' else 2
 
+        jth = {1: '1st', 2: '2nd', 3: '3rd'}.get(j, f'{j}th')
+
         d2im = [
             (f'D2IMERR{j:1d}', error_val, f'Maximum error of D2IM correction for axis {j:d}'),
             (f'D2IMDIS{j:1d}', 'Lookup', 'Detector to image correction type'),
             (f'D2IM{j:1d}.EXTVER', wdvarr_ver, 'Version number of WCSDVARR extension'),
             (f'D2IM{j:1d}.NAXES', 2, 'Number of independent variables in D2IM function'),
-            (f'D2IM{j:1d}.AXIS.1', 1, 'Axis number of the jth variable in a D2IM function'),
-            (f'D2IM{j:1d}.AXIS.2', 2, 'Axis number of the jth variable in a D2IM function'),
+            (f'D2IM{j:1d}.AXIS.1', 1, 'Axis number of the {jth} variable in a D2IM function'),
+            (f'D2IM{j:1d}.AXIS.2', 2, 'Axis number of the {jth} variable in a D2IM function'),
         ]
 
         # Look for HISTORY keywords. If present, insert new keywords before them

--- a/stwcs/updatewcs/det2im.py
+++ b/stwcs/updatewcs/det2im.py
@@ -115,39 +115,23 @@ class DET2IMCorr(object):
         Adds kw to sci extension to define WCSDVARR lookup table extensions
 
         """
-        if d2im_extname == 'DX':
-            j = 1
-        else:
-            j = 2
+        j = 1 if d2im_extname == 'DX' else 2
 
-        d2imerror = 'D2IMERR%s' % j
-        d2imdis = 'D2IMDIS%s' % j
-        d2imext = 'D2IM%s.' % j + 'EXTVER'
-        d2imnaxes = 'D2IM%s.' % j + 'NAXES'
-        d2imaxis1 = 'D2IM%s.' % j + 'AXIS.1'
-        d2imaxis2 = 'D2IM%s.' % j + 'AXIS.2'
-        keys = [d2imerror, d2imdis, d2imext, d2imnaxes, d2imaxis1, d2imaxis2]
-        values = {d2imerror: error_val,
-                  d2imdis: 'Lookup',
-                  d2imext: wdvarr_ver,
-                  d2imnaxes: 2,
-                  d2imaxis1: 1,
-                  d2imaxis2: 2}
+        d2im = [
+            (f'D2IMERR{j:1d}', error_val, f'Maximum error of D2IM correction for axis {j:d}'),
+            (f'D2IMDIS{j:1d}', 'Lookup', 'Detector to image correction type'),
+            (f'D2IM{j:1d}.EXTVER', wdvarr_ver, 'Version number of WCSDVARR extension'),
+            (f'D2IM{j:1d}.NAXES', 2, 'Number of independent variables in D2IM function'),
+            (f'D2IM{j:1d}.AXIS.1', 1, 'Axis number of the jth variable in a D2IM function'),
+            (f'D2IM{j:1d}.AXIS.2', 2, 'Axis number of the jth variable in a D2IM function'),
+        ]
 
-        comments = {d2imerror: 'Maximum error of NPOL correction for axis %s' % j,
-                    d2imdis: 'Detector to image correction type',
-                    d2imext: 'Version number of WCSDVARR extension containing d2im lookup table',
-                    d2imnaxes: 'Number of independent variables in d2im function',
-                    d2imaxis1: 'Axis number of the jth independent variable in a d2im function',
-                    d2imaxis2: 'Axis number of the jth independent variable in a d2im function'
-                    }
         # Look for HISTORY keywords. If present, insert new keywords before them
-        before_key = 'HISTORY'
-        if before_key not in hdr:
-            before_key = None
+        before_key = 'HISTORY' if 'HISTORY' in hdr else None
 
-        for key in keys:
-            hdr.set(key, value=values[key], comment=comments[key], before=before_key)
+        for key, value, comment in d2im:
+            hdr.set(key, value=value, comment=comment, before=before_key)
+
 
     addSciExtKw = classmethod(addSciExtKw)
 

--- a/stwcs/updatewcs/npol.py
+++ b/stwcs/updatewcs/npol.py
@@ -130,13 +130,15 @@ class NPOLCorr(object):
         """
         j = 1 if npol_extname == 'DX' else 2
 
+        jth = {1: '1st', 2: '2nd', 3: '3rd'}.get(j, f'{j}th')
+
         npol = [
             (f'CPERR{j:1d}', error_val, f'Maximum error of NPOL correction for axis {j:d}'),
             (f'CPDIS{j:1d}', 'Lookup', 'Prior distortion function type'),
             (f'DP{j:1d}.EXTVER', wdvarr_ver, 'Version number of WCSDVARR extension'),
             (f'DP{j:1d}.NAXES', 2, 'Number of independent variables in CPDIS function'),
-            (f'DP{j:1d}.AXIS.1', 1, 'Axis number of the jth variable in a CPDIS function'),
-            (f'DP{j:1d}.AXIS.2', 2, 'Axis number of the jth variable in a CPDIS function'),
+            (f'DP{j:1d}.AXIS.1', 1, 'Axis number of the {jth} variable in a CPDIS function'),
+            (f'DP{j:1d}.AXIS.2', 2, 'Axis number of the {jth} variable in a CPDIS function'),
         ]
 
         # Look for HISTORY keywords. If present, insert new keywords before them

--- a/stwcs/updatewcs/npol.py
+++ b/stwcs/updatewcs/npol.py
@@ -128,39 +128,23 @@ class NPOLCorr(object):
         Adds kw to sci extension to define WCSDVARR lookup table extensions
 
         """
-        if npol_extname == 'DX':
-            j = 1
-        else:
-            j = 2
+        j = 1 if npol_extname == 'DX' else 2
 
-        cperror = 'CPERR%s' % j
-        cpdis = 'CPDIS%s' % j
-        dpext = 'DP%s.' % j + 'EXTVER'
-        dpnaxes = 'DP%s.' % j + 'NAXES'
-        dpaxis1 = 'DP%s.' % j + 'AXIS.1'
-        dpaxis2 = 'DP%s.' % j + 'AXIS.2'
-        keys = [cperror, cpdis, dpext, dpnaxes, dpaxis1, dpaxis2]
-        values = {cperror: error_val,
-                  cpdis: 'Lookup',
-                  dpext: wdvarr_ver,
-                  dpnaxes: 2,
-                  dpaxis1: 1,
-                  dpaxis2: 2}
+        npol = [
+            (f'CPERR{j:1d}', error_val, f'Maximum error of NPOL correction for axis {j:d}'),
+            (f'CPDIS{j:1d}', 'Lookup', 'Prior distortion function type'),
+            (f'DP{j:1d}.EXTVER', wdvarr_ver, 'Version number of WCSDVARR extension'),
+            (f'DP{j:1d}.NAXES', 2, 'Number of independent variables in CPDIS function'),
+            (f'DP{j:1d}.AXIS.1', 1, 'Axis number of the jth variable in a CPDIS function'),
+            (f'DP{j:1d}.AXIS.2', 2, 'Axis number of the jth variable in a CPDIS function'),
+        ]
 
-        comments = {cperror: 'Maximum error of NPOL correction for axis %s' % j,
-                    cpdis: 'Prior distortion function type',
-                    dpext: 'Version number of WCSDVARR extension containing lookup distortion table',
-                    dpnaxes: 'Number of independent variables in distortion function',
-                    dpaxis1: 'Axis number of the jth independent variable in a distortion function',
-                    dpaxis2: 'Axis number of the jth independent variable in a distortion function'
-                    }
         # Look for HISTORY keywords. If present, insert new keywords before them
-        before_key = 'HISTORY'
-        if before_key not in hdr:
-            before_key = None
+        before_key = 'HISTORY' if 'HISTORY' in hdr else None
 
-        for key in keys:
-            hdr.set(key, value=values[key], comment=comments[key], before=before_key)
+        for key, value, comment in npol:
+            hdr.set(key, value=value, comment=comment, before=before_key)
+
 
     addSciExtKw = classmethod(addSciExtKw)
 


### PR DESCRIPTION
This PR shortens comment strings for some `D2IM` and `CPDIS` FITS keywords to reduce the number of warning when working with WCSes containing lookup table distortions.

Here is an example of how some comments are currently truncated in FITS headers:
```
D2IM1   = 'AXIS.1: 1' / Axis number of the jth independent variable in a d2im fu
D2IM1   = 'AXIS.2: 2' / Axis number of the jth independent variable in a d2im fu
```

As a result, when running `stwcs.updatewcs.updatewcs()` function on such WCSes produces warnings like these:
```
WARNING: VerifyWarning: Card is too long, comment will be truncated. [astropy.io.fits.card]
```

This PR solves this issue by removing the word `independent` from the comment for "axis number". This PR also modifies the comment for `CPDIS` to contain the distortion function name (`'CPDIS'`) in a similar way to `D2IM` distortion.

This PR is a mirroring https://github.com/astropy/astropy/pull/10513 so that both packages writes similar comments.