### PR TITLE
Performance and reliability improvements

### DIFF
--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -646,7 +646,23 @@ def wcskeys(fobj, ext=None):
 
 
 def _alt_wcs_names(hdr, del_opus=True):
-    """ Return a dictionary of all alternate WCS keys with names except OPUS """
+    """ Return a dictionary of all alternate WCS keys with names except ``OPUS``
+
+    Parameters
+    ----------
+    hdr : astropy.io.fits.Header
+        An image header.
+
+    del_opus : bool
+        Indicates whether to remove ``OPUS`` entry (WCS key ``'O'``) from
+        returned key-name dictionary.
+
+    Returns
+    -------
+    wnames : dict
+        A dictionary of **Alt** WCS keys and names (as values):
+
+    """
     names = hdr["WCSNAME?"]
 
     if del_opus and 'WCSNAMEO' in names and names['WCSNAMEO'] == 'OPUS':

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -675,7 +675,7 @@ def _alt_wcs_names(hdr, del_opus=True):
     return wnames
 
 
-def wcsnames(fobj, ext=None):
+def wcsnames(fobj, ext=None, include_primary=True):
     """
     Returns a dictionary of wcskey: WCSNAME pairs
 
@@ -690,7 +690,10 @@ def wcsnames(fobj, ext=None):
     """
     _check_headerpars(fobj, ext)
     hdr = _getheader(fobj, ext)
-    return _alt_wcs_names(hdr, del_opus=False)
+    names = _alt_wcs_names(hdr, del_opus=False)
+    if include_primary and 'WCSNAME' in hdr:
+        names[' '] = hdr['WCSNAME']
+    return names
 
 
 def available_wcskeys(fobj, ext=None):

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -645,11 +645,11 @@ def wcskeys(fobj, ext=None):
     return sorted(wkeys)
 
 
-def _alt_wcs_names(hdr):
+def _alt_wcs_names(hdr, del_opus=True):
     """ Return a dictionary of all alternate WCS keys with names except OPUS """
     names = hdr["WCSNAME?"]
 
-    if 'WCSNAMEO' in names and names['WCSNAMEO'] == 'OPUS':
+    if del_opus and 'WCSNAMEO' in names and names['WCSNAMEO'] == 'OPUS':
         # remove OPUS name
         del names['WCSNAMEO']
 
@@ -674,7 +674,7 @@ def wcsnames(fobj, ext=None):
     """
     _check_headerpars(fobj, ext)
     hdr = _getheader(fobj, ext)
-    return _alt_wcs_names(hdr)
+    return _alt_wcs_names(hdr, del_opus=False)
 
 
 def available_wcskeys(fobj, ext=None):

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -102,13 +102,13 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
 
     elif wcskey == " ":
         # wcsname exists, overwrite it if reuse is True or get the next key
-        if wcsname in wcsnames(f[wcsext].header).values():
+        if wcsname in _alt_wcs_names(f[wcsext].header).values():
             if reusekey:
                 # try getting the key from an existing WCS with WCSNAME
                 wkey = getKeyFromName(f[wcsext].header, wcsname)
                 wname = wcsname
                 if wkey == ' ':
-                    wkey = next_wcskey(f[wcsext].header)
+                    wkey = _next_wcskey(f[wcsext].header)
                 elif wkey is None:
                     closefobj(fname, f)
                     raise KeyError(f"Could not get a valid wcskey from wcsname '{wcsname:s}'")
@@ -122,14 +122,12 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
                 )
 
         else:
-            wkey = next_wcskey(f[wcsext].header)
+            wkey = _next_wcskey(f[wcsext].header)
             if wcsname != ' ':
                 wname = wcsname
             else:
                 # determine which WCSNAME needs to be replicated in archived WCS
-                wnames = wcsnames(f[wcsext].header)
-                if 'O' in wnames:
-                    del wnames['O']  # we don't want OPUS/original
+                wnames = _alt_wcs_names(f[wcsext].header)
 
                 if len(wnames) > 0:
                     if ' ' in wnames:
@@ -628,13 +626,37 @@ def wcskeys(fobj, ext=None):
     _check_headerpars(fobj, ext)
     hdr = _getheader(fobj, ext)
 
+    wcs_kwd_list = ['WCSNAME', 'CTYPE1', 'CRPIX1', 'CRVAL1', 'RADESYS', 'LONPOLE']
+
     wkeys = set()
-    for kwd in ['WCSNAME', 'CTYPE1', 'CRPIX1', 'CRVAL1', 'RADESYS', 'LONPOLE']:
-        alt_kwd = hdr[kwd + '*']
-        wkeys.update([key.replace(kwd, '').strip().upper().ljust(1, ' ')
-                      for key in alt_kwd])
+
+    # check primary:
+    for kwd in wcs_kwd_list:
+        if kwd in hdr:
+            wkeys.add(' ')
+            break
+
+    # check Alt WCS:
+    for kwd in wcs_kwd_list:
+        alt_kwds = hdr[kwd + '?']
+        alt_keys = [key[-1].upper() for key in alt_kwds if key[-1] in string.ascii_letters]
+        wkeys.update(alt_keys)
 
     return sorted(wkeys)
+
+
+def _alt_wcs_names(hdr):
+    """ Return a dictionary of all alternate WCS keys with names except OPUS """
+    names = hdr["WCSNAME?"]
+
+    if 'WCSNAMEO' in names and names['WCSNAMEO'] == 'OPUS':
+        # remove OPUS name
+        del names['WCSNAMEO']
+
+    wnames = {kwd[-1].upper(): val for kwd, val in names.items()
+              if kwd[-1] in string.ascii_letters}
+
+    return wnames
 
 
 def wcsnames(fobj, ext=None):
@@ -652,10 +674,7 @@ def wcsnames(fobj, ext=None):
     """
     _check_headerpars(fobj, ext)
     hdr = _getheader(fobj, ext)
-    names = hdr["WCSNAME*"]
-    wnames = {kwd.replace('WCSNAME', '').strip().upper().ljust(1, ' '): val
-              for kwd, val in names.items()}
-    return wnames
+    return _alt_wcs_names(hdr)
 
 
 def available_wcskeys(fobj, ext=None):
@@ -691,11 +710,28 @@ def next_wcskey(fobj, ext=None):
     """
     _check_headerpars(fobj, ext)
     hdr = _getheader(fobj, ext)
-    allkeys = available_wcskeys(hdr)
-    if allkeys:
-        return allkeys[0]
-    else:
-        return None
+    return _next_wcskey(hdr)
+
+
+def _next_wcskey(hdr):
+    """
+    Returns next available character to be used for an alternate WCS
+
+    Parameters
+    ----------
+    hdr : `astropy.io.fits.Header`
+        FITS header.
+
+    Returns
+    -------
+    key : str, None
+        Next available character to be used as an alternate WCS key or `None`
+        if none is available.
+
+    """
+    all_keys = available_wcskeys(hdr)
+    key = all_keys[0] if all_keys else None
+    return key
 
 
 def getKeyFromName(header, wcsname):
@@ -713,8 +749,7 @@ def getKeyFromName(header, wcsname):
     names = wcsnames(header)
     wkeys = [key for key, name in names.items() if name.lower() == wcsname.lower()]
     if wkeys:
-        wkeys.sort()
-        wkey = wkeys[-1]
+        wkey = max(wkeys)
     else:
         wkey = None
     return wkey

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1969,13 +1969,13 @@ class Headerlet(fits.HDUList):
                                                                           suffix='_idc')])
                         else:
                             priwcs_name = 'UNKNOWN'
-                nextkey = altwcs.next_wcskey(fobj, ext=target_ext)
+                nextkey = altwcs._next_wcskey(fobj[target_ext].header)
                 altwcs.archiveWCS(fobj, ext=sciext_list, wcskey=nextkey,
                                   wcsname=priwcs_name)
             else:
-                for hname in altwcs.wcsnames(fobj, ext=target_ext).values():
-                    if hname != 'OPUS' and hname not in hdrlet_extnames:
-                        nextkey = altwcs.next_wcskey(fobj, ext=target_ext)
+                for hname in altwcs._alt_wcs_names(fobj[target_ext].header).values():
+                    if hname not in hdrlet_extnames:
+                        nextkey = altwcs._next_wcskey(fobj[target_ext].header)
                         # Archive original WCS as alternate WCS with its own key
                         altwcs.archiveWCS(fobj, ext=sciext_list, wcskey=nextkey,
                                   wcsname=hname)
@@ -2149,7 +2149,7 @@ class Headerlet(fits.HDUList):
         tg_ever = self[('SIPWCS', 1)].header['TG_EVER']
         # determine what alternate WCS this headerlet will be assigned to
         if wcskey is None:
-            wkey = altwcs.next_wcskey(fobj[(tg_ename, tg_ever)].header)
+            wkey = altwcs._next_wcskey(fobj[(tg_ename, tg_ever)].header)
         else:
             wcskey = wcskey.upper()
             available_keys = altwcs.available_wcskeys(fobj[(tg_ename, tg_ever)].header)

--- a/stwcs/wcsutil/wcscorr.py
+++ b/stwcs/wcsutil/wcscorr.py
@@ -309,7 +309,7 @@ def update_wcscorr(dest, source=None, extname='SCI', wcs_id=None, active=True):
     # apply logic for only updating WCSCORR table with specified keywords
     # corresponding to the WCS with WCSNAME=wcs_id
     if wcs_id is not None:
-        wnames = altwcs.wcsnames(source[(extname, 1)].header)
+        wnames = altwcs._alt_wcs_names(source[(extname, 1)].header)
         wkeys = []
         for letter in wnames:
             if wnames[letter] == wcs_id:
@@ -319,9 +319,6 @@ def update_wcscorr(dest, source=None, extname='SCI', wcs_id=None, active=True):
         wcs_keys = wkeys
     wcshdr = stwcs.wcsutil.HSTWCS(source, ext=(extname, 1)).wcs2header()
     wcs_keywords = list(wcshdr.keys())
-
-    if 'O' in wcs_keys:
-        wcs_keys.remove('O')  # 'O' is reserved for original OPUS WCS
 
     # create new table for hdr and populate it with the newly updated values
     new_table = create_wcscorr(descrip=True, numrows=0, padding=len(wcs_keys) * numext)

--- a/stwcs/wcsutil/wcscorr.py
+++ b/stwcs/wcsutil/wcscorr.py
@@ -304,16 +304,15 @@ def update_wcscorr(dest, source=None, extname='SCI', wcs_id=None, active=True):
     # extension version; if this should not be assumed then this can be
     # modified...
     wcs_keys = altwcs.wcskeys(source[(extname, 1)].header)
-    wcs_keys = [kk for kk in wcs_keys if kk]
+    if 'O' in wcs_keys:
+        del wcs_keys['O']  # 'O' is reserved for original OPUS WCS
     if ' ' not in wcs_keys: wcs_keys.append(' ')  # Insure that primary WCS gets used
     # apply logic for only updating WCSCORR table with specified keywords
     # corresponding to the WCS with WCSNAME=wcs_id
     if wcs_id is not None:
+        wcs_id_up = wcs_id.upper()
         wnames = altwcs._alt_wcs_names(source[(extname, 1)].header)
-        wkeys = []
-        for letter in wnames:
-            if wnames[letter] == wcs_id:
-                wkeys.append(letter)
+        wkeys = [key for key, name in wnames.items() if name.upper() == wcs_id_up]
         if len(wkeys) > 1 and ' ' in wkeys:
             wkeys.remove(' ')
         wcs_keys = wkeys

--- a/stwcs/wcsutil/wcscorr.py
+++ b/stwcs/wcsutil/wcscorr.py
@@ -327,10 +327,7 @@ def update_wcscorr(dest, source=None, extname='SCI', wcs_id=None, active=True):
     sipname, idctab = utils.build_sipname(source, fname, "None")
     npolname, npolfile = utils.build_npolname(source, None)
     d2imname, d2imfile = utils.build_d2imname(source, None)
-    if 'hdrname' in prihdr:
-        hdrname = prihdr['hdrname']
-    else:
-        hdrname = ''
+    hdrname = prihdr.get('hdrname', '')
 
     idx = -1
     for wcs_key in wcs_keys:


### PR DESCRIPTION
Several code enhancements:

1. `wcsnames()` and `next_wcskey()` accept `HDUList` of string file name and extension. However, most of the time calling code already performed most checks and repeating checks on input file name and extensions is not needed. `_next_wcskey()` and `_alt_wcs_names()` accept `Header` objects skipping `fobj` and `ext` checks;

2. ~In every case that I saw, having OPUS WCS returned by `wcsnames()` is not desirable. Often a call to `wcsnames()` is followed by deletion of the `'O'` key. `_alt_wcs_names()` removes OPUS WCS before returning `wcskey: name` dictionary.~

3. `wcskeys()` was enhanced to use `'?'` instead of `'*'` as wildcard since WCS keys are 1 character. This makes code more robust. 