### PR TITLE
Add HDRNAME and ORIENTAT to the list of STWCS keywords

### DIFF
--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -23,7 +23,7 @@ altwcskw_extra = ['LATPOLE', 'LONPOLE', 'RESTWAV', 'RESTFRQ']
 
 # List non-standard WCS keywords (such as those created, e.g., by TweakReg)
 # that need to be archived/restored with the rest of WCS here:
-STWCS_KWDS = ['WCSTYPE', 'RMS_RA', 'RMS_DEC', 'NMATCH', 'FITNAME']
+STWCS_KWDS = ['WCSTYPE', 'RMS_RA', 'RMS_DEC', 'NMATCH', 'FITNAME', 'HDRNAME', 'ORIENTAT']
 
 # file operations
 


### PR DESCRIPTION
Expands the list of STWCS-specific keywords that need to be archived/restored/deleted by `altwcs` first defined in #135 