### PR TITLE
Undo adding ORIENTAT to STWCS-specific keywords

### DIFF
--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -24,7 +24,7 @@ altwcskw_extra = ['LATPOLE', 'LONPOLE', 'RESTWAV', 'RESTFRQ']
 
 # List non-standard WCS keywords (such as those created, e.g., by TweakReg)
 # that need to be archived/restored with the rest of WCS here:
-STWCS_KWDS = ['WCSTYPE', 'RMS_RA', 'RMS_DEC', 'NMATCH', 'FITNAME', 'HDRNAME', 'ORIENTAT']
+STWCS_KWDS = ['WCSTYPE', 'RMS_RA', 'RMS_DEC', 'NMATCH', 'FITNAME', 'HDRNAME']
 
 _DEFAULT_WCSNAME = 'ARCHIVED_WCS'
 


### PR DESCRIPTION
Partially undoes https://github.com/spacetelescope/stwcs/pull/154 by removing `'ORIENTAT'` from the list of STWCS-specific keywords. This is due to the fact that length of `'ORIENTAT'` is 8 an adding alternate WCS key results in creation of `'HIERARCH'` cards.