### PR TITLE
Do not archive primary WCS when changing distortion model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@
 - Remove HST-specific WCS keywords from SCI extensions that, following HST
   convention, are supposed to be present in primary header only. [#159]
 
+- Do not archive primary WCS when applying headerlet as primary if distortion
+  model changes. [#161]
+
 
 1.5.3 (2019-09-23)
 ------------------

--- a/stwcs/tests/test_altwcs.py
+++ b/stwcs/tests/test_altwcs.py
@@ -257,15 +257,14 @@ class TestAltWCS(object):
         h = pyfits.open(self.acs_file, mode='update')
         for ext in ext_list:
             wnames = altwcs.wcsnames(h, ext=ext)
-            assert not set(altwcs.wcskeys(h, ext)).symmetric_difference(['O', ' ', 'A', 'B'])
-            assert wnames['A'].upper() == 'IDC_POSTSM4'
+            assert not set(altwcs.wcskeys(h, ext)).symmetric_difference(['O', ' ', 'A'])
+            assert wnames['A'].upper() == 'IDC_0461802EJ'
             assert '-FIT' in wnames[' '].upper() and 'IDC_0461802EJ' in wnames[' '].upper()
             assert not np.allclose(h[ext].header['CD1_1'], ext[1] + 0.234)
             assert 'HDRNAME' in h[ext].header
 
             # check that original primary WCS is stored under key 'A':
             wcsa = wcsutil.HSTWCS(h, ext, wcskey='A')
-            compare_wcs(ref_priwcs[ext], wcsa)
 
         h.close()
 

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1997,12 +1997,11 @@ class Headerlet(fits.HDUList):
                     altwcs.archive_wcs(fobj, ext=sciext_list, mode=mode)
 
             else:
-                # explicity pass wcsname so that if a WCS with the same name
-                # already exists, overwrite it in place:
-                pri_wcsname = scihdr.get('WCSNAME', None)
-                altwcs.archive_wcs(fobj, ext=sciext_list, wcsname=pri_wcsname, mode=mode)
+                # Add primary WCS to the list of WCS to be saved to headerlets:
+                all_wcs_dict = alt_wcs_names_dict.copy()
+                all_wcs_dict[' '] = scihdr.get('WCSNAME', ' ')
 
-                for wcskey, hname in alt_wcs_names_dict:
+                for wcskey, hname in all_wcs_dict.items():
                     if hname not in hdrlet_extnames:
                         # create HeaderletHDU for alternate WCS now
                         alt_hlet = create_headerlet(fobj, sciext=sciext_list,
@@ -2016,6 +2015,8 @@ class Headerlet(fits.HDUList):
                         alt_hlet_hdu.header['EXTVER'] = numhlt
                         alt_hlethdu.append(alt_hlet_hdu)
                         hdrlet_extnames.append(hname)
+
+                    altwcs.deleteWCS(fobj, sciext_list, wcskey=wcskey, wcsname=hname)
 
         self._del_dest_WCS_ext(fobj)
         for i in range(1, numsip + 1):


### PR DESCRIPTION
When distortion model of the headerlet being applied as primary is different from the current distortion model in the header, the primary WCS should not be archived as loading it back from an alternate WCS would result in incorrect WCS that uses a distortion model not intended for it.

Also, for the same reason, this PR deletes all Alt WCSes before applying a headerlet with a different distortion model.

Fixes #160