### PR TITLE
Deprecate "accuracy" in favor of "tolerance" in all_world2pix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 - Make WCS and headerlet name comparisons case-insensitive when applying
   headerlets. [#163]
 
+- Deprecate ``accuracy`` argument in ``all_world2pix`` and replace it with
+  ``tolerance`` in order to have compatible function signature with
+  ``astropy``'s ``all_world2pix()``'. [#166]
+
 
 1.6.0 (2020-07-16)
 ------------------


### PR DESCRIPTION
`astropy.wcs.WCS.all_world2pix` uses `tolerance` instead of `accuracy` that is used in `stwcs.HSTWCS.all_world2pix` to describe desired accuracy of the results. This PR makes the arguments of both functions compatible (match).