### PR TITLE
Compute new apriori WCS 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+1.6.2 (Unreleased)
+------------------
+
+- Add support for computing new `a priori` WCS solutions when running
+  ``updatewcs``. [#169]
+
+ - Add new parameter to ``updatewcs`` to limit the astrometry database
+   WCSs appended to the file to only those based on the same IDCTAB as
+   specified in the image header. [#169]
+
+
 1.6.1 (2020-12-09)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,11 +2,11 @@
 ------------------
 
 - Add support for computing new `a priori` WCS solutions when running
-  ``updatewcs``. [#169]
+  ``updatewcs``. [#170]
 
  - Add new parameter to ``updatewcs`` to limit the astrometry database
    WCSs appended to the file to only those based on the same IDCTAB as
-   specified in the image header. [#169]
+   specified in the image header. [#170]
 
 
 1.6.1 (2020-12-09)

--- a/stwcs/distortion/utils.py
+++ b/stwcs/distortion/utils.py
@@ -23,7 +23,7 @@ def output_wcs(list_of_wcsobj, ref_wcs=None, owcs=None, undistort=True):
              is used as a reference
     outwcs:  an HSTWCS object
              the tangent plane defined by this object is used as a reference
-    undistort: boolean (default-True)
+    undistort: bool (default-True)
               a flag whether to create an undistorted output WCS
     """
     fra_dec = np.vstack([w.calc_footprint() for w in list_of_wcsobj])

--- a/stwcs/tests/test_altwcs.py
+++ b/stwcs/tests/test_altwcs.py
@@ -175,11 +175,17 @@ class TestAltWCS(object):
         #assert(not altwcs._parpasscheck(f, ext=1, wcskey='O', reusekey=False))
         f.close()
 
-    def _prepare_acs_test_file(self, ext_list):
+    def _prepare_acs_test_file(self, ext_list, regression=True):
         shutil.copyfile(self.acs_orig_file, self.acs_file)
-        idctab = get_filepath('postsm4_idc.fits')
-        npol_file = get_filepath('qbu16424j_npl.fits')
-        d2imfile = get_filepath('new_wfc_d2i.fits ')
+        if regression:
+            idctab = get_filepath('postsm4_idc.fits')
+            npol_file = get_filepath('qbu16424j_npl.fits')
+            d2imfile = get_filepath('new_wfc_d2i.fits ')
+        else:
+            idctab = get_filepath('0461802ej_idc.fits')
+            npol_file = get_filepath('02c14514j_npl.fits')
+            d2imfile = get_filepath('02c1450oj_d2i.fits')
+
         pyfits.setval(self.acs_file, ext=0, keyword="IDCTAB", value=idctab)
         pyfits.setval(self.acs_file, ext=0, keyword="NPOLFILE", value=npol_file)
         pyfits.setval(self.acs_file, ext=0, keyword="D2IMFILE", value=d2imfile)
@@ -236,8 +242,9 @@ class TestAltWCS(object):
 
 
     def test_repeated_updatewcs_use_db(self):
+        """Expectation: All WCSs in header should be based on IDCTAB value from input image header."""
         ext_list = [('sci', 1), ('sci', 2)]
-        self._prepare_acs_test_file(ext_list)
+        self._prepare_acs_test_file(ext_list, regression=False)
 
         ref_priwcs = {}
         h = pyfits.open(self.acs_file)
@@ -269,6 +276,4 @@ class TestAltWCS(object):
         h.close()
 
         # remove all Alt WCS except OPUS:
-        self._prepare_acs_test_file(ext_list)
-
-
+        self._prepare_acs_test_file(ext_list, regression=False)

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -30,7 +30,7 @@ atexit.register(logging.shutdown)
 warnings.filterwarnings("ignore", message="^Some non-standard WCS keywords were excluded:", module="astropy.wcs")
 
 def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
-              checkfiles=True, verbose=False, use_db=True):
+              checkfiles=True, verbose=False, use_db=True, all_wcs=False):
     """
 
     Updates HST science files with the best available calibration information.
@@ -75,6 +75,13 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
               If True, attempt to add astrometric solutions from the
               MAST astrometry database.
               Default value is True.
+
+    all_wcs : boolean
+              This parameter only gets used if `use_db=True` to control
+              what WCS solutions from the Astrometry database gets appended
+              to the file.  If True, all solutions get appended.  If False,
+              only solutions based on the IDCTAB from the file's PRIMARY
+              header will be appended.
     """
     if not verbose:
         logger.setLevel(100)
@@ -136,7 +143,7 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
         if use_db:
             # Add any new astrometry solutions available from
             #  an accessible astrometry web-service
-            astrometry.updateObs(f)
+            astrometry.updateObs(f, all_wcs=all_wcs)
 
         if toclose:
             f.close()

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -59,24 +59,24 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
     input : a python list of file names or a string (wild card
              characters allowed) input files may be in fits, geis or
              waiver fits format
-    vacorr : boolean
+    vacorr : bool
               If True, vecocity aberration correction will be applied
-    tddcorr : boolean
+    tddcorr : bool
              If True, time dependent distortion correction will be applied
-    npolcorr : boolean
+    npolcorr : bool
               If True, a Lookup table distortion will be applied
-    d2imcorr : boolean
+    d2imcorr : bool
               If True, detector to image correction will be applied
-    checkfiles : boolean
+    checkfiles : bool
               If True, the format of the input files will be checked,
               geis and waiver fits files will be converted to MEF format.
               Default value is True for standalone mode.
-    use_db : boolean
+    use_db : bool
               If True, attempt to add astrometric solutions from the
               MAST astrometry database.
               Default value is True.
 
-    all_wcs : boolean
+    all_wcs : bool
               This parameter only gets used if `use_db=True` to control
               what WCS solutions from the Astrometry database gets appended
               to the file.  If True, all solutions get appended.  If False,

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -162,7 +162,7 @@ class AstrometryDB(object):
         obsname : str
            Filename for observation to be updated
 
-        all_wcs : boolean
+        all_wcs : bool
             If True, all solutions from the Astrometry database
             gets appended.  If False, only those based on the
             same IDCTAB will be appended.

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -202,10 +202,10 @@ class AstrometryDB(object):
         # Determine what WCSs to append to this observation
         # If headerlet found in database, update file with all new WCS solutions
         # according to the 'all_wcs' parameter
+        num_appended = 0
         if not self.new_observation:
             # Attach new unique hdrlets to file...
             logger.info("Updating {} with:".format(observationID))
-            num_appended = 0
             for h in headerlets:
                 newname = headerlets[h][0].header['wcsname']
                 # Only append the WCS from the database if `all_wcs` was turned on,
@@ -260,7 +260,7 @@ class AstrometryDB(object):
 
         # Insure changes are written to the file and that the file is closed.
         if obs_open:
-            fits.close(obsname)
+            obsname.close()
 
     def findObservation(self, observationID):
         """Find whether there are any entries in the AstrometryDB for
@@ -564,7 +564,7 @@ class AstrometryDB(object):
 
             # Now, write out pipeline-default WCS to a unique headerlet file
             logger.info("Writing out pipeline-default WCS {} to headerlet file: {}".format(wname, hfilename))
-            headerlet.extract_headerlet(obsname, hfilename, extnum=numext)
+            headerlet.extract_headerlet(obsname, hfilename, extnum=numext, clobber=True)
 
         # We need to create new apriori WCS based on new IDCTAB
         # Get guide star offsets from DB
@@ -612,7 +612,7 @@ class AstrometryDB(object):
 
         # Now, write out new a priori WCS to a unique headerlet file
         logger.info("Writing out a priori WCS {} to headerlet file: {}".format(wname, hfilename))
-        headerlet.extract_headerlet(obsname, hfilename, extnum=numext)
+        headerlet.extract_headerlet(obsname, hfilename, extnum=numext, clobber=True)
 
         return wname
 

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -212,8 +212,9 @@ class AstrometryDB(object):
                 # Only append the WCS from the database if `all_wcs` was turned on,
                 # or the WCS was based on the same IDCTAB as in the image header.
                 append_wcs = True if ((idcroot in newname) or all_wcs or newname == 'OPUS') else False
-                if append_wcs:
+                if append_wcs and newname != 'OPUS':
                     num_appended += 1
+
                 # Check to see whether this WCS has already been appended or
                 # if it was never intended to be appended.  If so, skip it.
                 if (newname in wcsnames and append_wcs) or not append_wcs:
@@ -484,10 +485,10 @@ class AstrometryDB(object):
         old_gs = (dGSinputRA, dGSinputDEC)
         new_gs = (dGSoutputRA, dGSoutputDEC)
 
-        if delta_ra != 0.0 and delta_dec != 0.0:
+        expwcs = build_reference_wcs(obsname)
 
+        if delta_ra != 0.0 and delta_dec != 0.0:
             # Compute tangent plane for this observation
-            expwcs = build_reference_wcs(obsname)
             wcsframe = expwcs.wcs.radesys.lower()
 
             # Use WCS to compute offset in pixels of shift applied to WCS Reference pixel

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -591,28 +591,30 @@ class AstrometryDB(object):
         hdrname = "{}_{}".format(filename.replace('.fits', ''), wname)
         # Create full filename for headerlet:
         hfilename = "{}_hlet.fits".format(hdrname)
-        newhlt += 1
-        numext = len(obsname)
-        descrip = "A Priori WCS based on ICRS guide star positions"
-        logger.info("Appending a priori WCS {} to {}".format(wname, filename))
-        headerlet.archive_as_headerlet(obsname, hfilename,
-                                       sciext='SCI',
-                                       wcskey="PRIMARY",
-                                       author="stwcs.updatewcs",
-                                       descrip=descrip)
-        obsname[numext].header['EXTVER'] = newhlt
-        # Update a priori headerlet with offsets used to compute new WCS
-        apriori_hdr = obsname[numext].headerlet[0].header
-        apriori_hdr['D_RA'] = pix_offsets['delta_ra']
-        apriori_hdr['D_DEC'] = pix_offsets['delta_dec']
-        apriori_hdr['D_ROLL'] = pix_offsets['roll']
-        apriori_hdr['D_SCALE'] = pix_offsets['scale']
-        apriori_hdr['NMATCH'] = 2
-        apriori_hdr['CATALOG'] = pix_offsets['catalog']
+        if wname not in hlet_names:
+            newhlt += 1
+            numext = len(obsname)
+            descrip = "A Priori WCS based on ICRS guide star positions"
+            logger.info("Appending a priori WCS {} to {}".format(wname, filename))
+            headerlet.archive_as_headerlet(obsname, hfilename,
+                                           sciext='SCI',
+                                           wcskey="PRIMARY",
+                                           author="stwcs.updatewcs",
+                                           descrip=descrip)
+            obsname[numext].header['EXTVER'] = newhlt
+            # Update a priori headerlet with offsets used to compute new WCS
+            apriori_hdr = obsname[numext].headerlet[0].header
+            apriori_hdr['D_RA'] = pix_offsets['delta_ra']
+            apriori_hdr['D_DEC'] = pix_offsets['delta_dec']
+            apriori_hdr['D_ROLL'] = pix_offsets['roll']
+            apriori_hdr['D_SCALE'] = pix_offsets['scale']
+            apriori_hdr['NMATCH'] = 2
+            apriori_hdr['CATALOG'] = pix_offsets['catalog']
 
-        # Now, write out new a priori WCS to a unique headerlet file
-        logger.info("Writing out a priori WCS {} to headerlet file: {}".format(wname, hfilename))
-        headerlet.extract_headerlet(obsname, hfilename, extnum=numext, clobber=True)
+        if not os.path.exists(hfilename):
+            # Now, write out new a priori WCS to a unique headerlet file
+            logger.info("Writing out a priori WCS {} to headerlet file: {}".format(wname, hfilename))
+            headerlet.extract_headerlet(obsname, hfilename, extnum=numext)
 
         return wname
 

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -426,7 +426,8 @@ class AstrometryDB(object):
         The default transform is GSC2-GAIA. The options were primarily for transforming
         individual objects from the catalogs and that is not specified in the limited
         documentation. The ipppssoot input is a special case where it pulls the gsids,
-        epoch and refframe from the dms databases and overrides the transform using this logic.
+        epoch and refframe from the dms databases and overrides the transform using this logic::
+
             REFFRAME=GSC1 sets GSC1-GAIA
             REFFRAME=ICRS and EPOCH < 2017.75 sets GSC2-GAIA
             REFFRAME=ICRS and EPOCH > 2017.75 sets no-offset since it's already in GAIA frame
@@ -436,9 +437,7 @@ class AstrometryDB(object):
         deltas : dictionary
             Dict of offset, roll and scale in decimal degrees and pixels for image
             based on correction to guide star coordinates relative to GAIA.
-            Keys: delta_x, delta_y, delta_ra, delta_dec,
-                  roll, scale,
-                  expwcs, catalog
+            Keys: delta_x, delta_y, delta_ra, delta_dec, roll, scale, expwcs, catalog
         """
         # check to see whether any URL has been specified as an
         # environmental variable.

--- a/stwcs/updatewcs/updatehdr.py
+++ b/stwcs/updatewcs/updatehdr.py
@@ -369,7 +369,7 @@ def updatewcs_with_shift(image, reference, hdrname="",
 
    hdrname : str, optional
         Value of HDRNAME keyword for this new WCS.
-        
+
     wcsname : str, None, optional
         Label to give to new WCS solution being created by this fit. If
         a value of None is given, it will automatically use 'TWEAK' as the

--- a/stwcs/updatewcs/updatehdr.py
+++ b/stwcs/updatewcs/updatehdr.py
@@ -717,7 +717,9 @@ def update_wcs(image, extnum, new_wcs, wcsname="", reusename=False, verbose=Fals
                 "value for the 'wcsname' parameter needs to be specified."
             )
     elif close_file or image.fileinfo(0) is None or image.fileinfo(0)['filemode'] == 'update':
-        altwcs.archive_wcs(image, [extnum], wcsname=pri_wcsname, mode=altwcs.ArchiveMode.AUTO_RENAME)
+        # If an alternate WCS already exists for this wcsname, we don't need to create
+        # extra copies of this WCS, so quit nicely.
+        altwcs.archive_wcs(image, [extnum], wcsname=pri_wcsname, mode=altwcs.ArchiveMode.QUIET_ABORT)
 
     # Update Primary WCS:
     try:

--- a/stwcs/updatewcs/updatehdr.py
+++ b/stwcs/updatewcs/updatehdr.py
@@ -319,7 +319,8 @@ def update_from_shiftfile(shiftfile, wcsname=None, force=False):
                              force=force, **pars)
 
 
-def updatewcs_with_shift(image, reference, wcsname='TWEAK', reusename=False,
+def updatewcs_with_shift(image, reference, hdrname="",
+                         wcsname='TWEAK', reusename=False,
                          fitgeom='rscale', rot=0.0, scale=1.0,
                          xsh=0.0, ysh=0.0, fit=None, xrms=None, yrms=None,
                          verbose=False, force=False, sciext='SCI'):
@@ -366,6 +367,9 @@ def updatewcs_with_shift(image, reference, wcsname='TWEAK', reusename=False,
         used to define the tangent plane in which all the fit parameters
         (shift, rot, scale) were measured.
 
+   hdrname : str, optional
+        Value of HDRNAME keyword for this new WCS.
+        
     wcsname : str, None, optional
         Label to give to new WCS solution being created by this fit. If
         a value of None is given, it will automatically use 'TWEAK' as the
@@ -654,7 +658,9 @@ def update_refchip_with_shift(chip_wcs, wcslin, fitgeom='rscale',
 ###
 # Header keyword prefix related archive functions
 ###
-def update_wcs(image, extnum, new_wcs, wcsname="", reusename=False, verbose=False):
+def update_wcs(image, extnum, new_wcs,
+               wcsname="", hdrname="",
+               reusename=False, verbose=False):
     """
     Updates the WCS of the specified extension number with the new WCS
     after archiving the original WCS.
@@ -675,6 +681,9 @@ def update_wcs(image, extnum, new_wcs, wcsname="", reusename=False, verbose=Fals
 
     wcsname : str
         Label to give newly updated WCS
+
+    hdrname : str
+        Value of HDRNAME keyword for updated WCS
 
     reusename : bool
         User can choose whether to over-write WCS with same name or not.
@@ -736,6 +745,7 @@ def update_wcs(image, extnum, new_wcs, wcsname="", reusename=False, verbose=Fals
         wcs_hdr.set('WCSNAME', wcsname, before=0)
         wcs_hdr.set('WCSTYPE', interpret_wcsname_type(wcsname), after=0)
         wcs_hdr.set('ORIENTAT', new_wcs.orientat, after=len(wcs_hdr))
+        wcs_hdr.set('HDRNAME', hdrname, after=len(wcs_hdr))
         hdr.update(wcs_hdr)
         if 'nextend' in image[0].header:
             image[0].header['nextend'] = len(image) - 1

--- a/stwcs/updatewcs/updatehdr.py
+++ b/stwcs/updatewcs/updatehdr.py
@@ -1,0 +1,783 @@
+"""
+
+:Authors: Warren Hack, Mihai Cara
+
+:License: :doc:`LICENSE`
+
+"""
+import sys
+import logging
+import atexit
+
+from astropy.io import fits
+import numpy as np
+
+from astropy import wcs as pywcs
+
+from stsci.tools import fileutil
+from .. import wcsutil
+from ..wcsutil import wcscorr, altwcs
+
+__version__ = '0.4.0'
+__version_date__ = '13-July-2020'
+
+
+wcs_keys = ['CRVAL1', 'CRVAL2', 'CD1_1', 'CD1_2', 'CD2_1', 'CD2_2',
+            'CRPIX1', 'CRPIX2', 'ORIENTAT']
+
+_SHIFT_COLNAMES = ['xsh', 'ysh', 'rot', 'scale', 'xrms', 'yrms']
+
+blank_list = [None, '', ' ', 'None', 'INDEF']
+
+logger = logging.getLogger('stwcs.updatewcs.astrometry_utils')
+for h in logger.handlers:
+    if isinstance(h, logging.StreamHandler) and h.stream is sys.stdout:
+        break
+else:
+    logger.handlers.append(logging.StreamHandler(sys.stdout))
+atexit.register(logging.shutdown)
+
+#
+# Helper functions
+#
+def is_blank(val):
+    """ Determines whether or not a value is considered 'blank'.
+    """
+    return val in blank_list
+
+
+def get_extver_list(img, extname='SCI'):
+    """
+    Return a list of all extension versions with ``extname`` extension
+    names. If ``extname`` is `None`, return extension **numbers** of all
+    image-like extensions.
+
+    .. note::
+        If input image is a `~skypac.utils.ImageRef`, this function will
+        **not** modify its reference count.
+
+    Parameters
+    ----------
+    img: str, `astropy.io.fits.HDUList`, or `~skypac.utils.ImageRef`
+        Input image object. If ``img`` is a string object (file name) then that
+        file will be opened. If the file pointed to by the file name is a
+        GEIS or WAIVER FITS file, it will be converted to a simple/MEF FITS
+        format if ``clobber`` is `True`.
+
+    extname: str, optional
+        Indicates extension *name* for which all existing extension *versions*
+        should be found. If ``extname`` is `None`, then
+        `~skypac.utils.get_extver_list` will return a list of extension
+        *numbers* of all image-like extensions.
+
+    Returns
+    -------
+    extver: list
+        List of extension versions corresponding to the input ``extname``.
+        If ``extname`` is `None`, it will return a list of extension
+        *numbers* of all image-like extensions.
+
+    Raises
+    ------
+    IOError
+        Unable to open input image file.
+
+    TypeError
+        Argument `img` must be either a file name (str),
+        an `~.utils.ImageRef`, or a `astropy.io.fits.HDUList` object.
+
+    TypeError
+        Argument `extname` must be either a string or `None`.
+
+    See Also
+    --------
+    get_ext_list
+
+    Examples
+    --------
+    >>> get_extver_list('j9irw1rqq_flt.fits',extname='sci')
+    [1, 2]
+    >>> get_extver_list('j9irw1rqq_flt.fits',extname=None)
+    [1, 2, 3, 4, 5, 6, 8, 9, 10, 11
+
+    """
+    doRelease = False
+    if isinstance(img, fits.HDUList):
+        hdulist = img
+    elif isinstance(img, str):
+        try:
+            hdulist = fits.openImageEx(img, mode='readonly')
+        except IOError:
+            raise IOError("Unable to open file: \'{:s}\'".format(img))
+
+        doRelease = True
+
+    else:
+        raise TypeError("Argument 'img' must be either a file name (string), "
+                        "or an `astropy.io.fits.HDUList` object.")
+
+    # when extver is None - return the range of all 'image'-like FITS
+    # extensions
+    if extname is None:
+        extn = []
+        for i in range(len(hdulist)):
+            hdr = hdulist[i].header
+            if not ('NAXIS' in hdr and hdr['NAXIS'] == 2):
+                continue
+            if 'XTENSION' in hdr and \
+               hdr['XTENSION'].upper().strip() == 'IMAGE':
+                extn.append(i)
+            elif 'SIMPLE' in hdr:
+                extn.append(i)
+        if doRelease:
+            hdulist.close()
+        return extn
+
+    if not isinstance(extname, str):
+        if doRelease:
+            hdulist.close()
+        raise TypeError(
+            "Argument 'extname' must be either a string indicating the value"
+            "of the 'EXTNAME' keyword of the extensions whose versions are to "
+            "be returned or None to return extension numbers of all HDUs in "
+            "the 'img' FITS file."
+        )
+
+    extname = extname.upper()
+
+    extver = []
+    for e in hdulist:
+        if 'EXTNAME' in e.header and e.header['EXTNAME'].upper() == extname:
+            extver.append(e.header['EXTVER'] if 'EXTVER' in e.header else 1)
+
+    if doRelease:
+        hdulist.close()
+
+    return extver
+
+#
+# These functions are copied from stsci.skypac.utils
+# Author: M. Cara
+#
+def get_ext_list(img, extname='SCI'):
+    """
+    Return a list of all extension versions of ``extname`` extensions.
+    ``img`` can be either a file name or a `astropy.io.fits.HDUList` object.
+
+    This function is similar to :py:func:`get_extver_list`, the main
+    difference being that it returns a list of fully qualified extensions:
+    either tuples of the form `(extname, extver)` or integer extension
+    numbers (when ``extname`` is `None`).
+
+    See Also
+    --------
+    get_extver_list
+
+    Examples
+    --------
+    >>> get_ext_list('j9irw1rqq_flt.fits',extname='SCI')
+    [('SCI', 1), ('SCI', 2)]
+    >>> get_ext_list('j9irw1rqq_flt.fits',extname=None)
+    [1, 2, 3, 4, 5, 6, 8, 9, 10, 11]
+
+    """
+    extver = get_extver_list(img=img, extname=extname)
+    if extname is None:
+        return extver
+
+    extlist = [(extname, extv) for extv in extver]
+    return extlist
+
+
+def ext2str(ext, compact=False, default_extver=1):
+    """
+    Return a string representation of an extension specification.
+
+    Parameters
+    ----------
+    ext: tuple, int, str
+        Extension specification can be a tuple of the form (str,int), e.g.,
+        ('sci',1), an integer (extension number), or a string (extension
+        name).
+
+    compact: bool, optional
+        If ``compact`` is `True` the returned string will have extension
+        name quoted and separated by a comma from the extension number,
+        e.g., ``"'sci',1"``.
+        If ``compact`` is `False` the returned string will have extension
+        version immediately follow the extension name, e.g., ``'sci1'``.
+
+    default_extver: int, optional
+        Specifies the extension version to be used when the ``ext`` parameter
+        is a string (extension name).
+
+    Returns
+    -------
+    strext: str
+        String representation of extension specification ``ext``.
+
+    Raises
+    ------
+    TypeError
+        Unexpected extension type.
+
+    Examples
+    --------
+    >>> ext2str('sci',compact=False,default_extver=6)
+    "'sci',6"
+    >>> ext2str(('sci',2))
+    "'sci',2"
+    >>> ext2str(4)
+    '4'
+    >>> ext2str('dq')
+    "'dq',1"
+    >>> ext2str('dq',default_extver=2)
+    "'dq',2"
+    >>> ext2str('sci',compact=True,default_extver=2)
+    'sci2'
+
+    """
+    if isinstance(ext, tuple) and len(ext) == 2 and \
+       isinstance(ext[0], str) and isinstance(ext[1], int):
+        if compact:
+            return "{:s}{:d}".format(ext[0], ext[1])
+        else:
+            return "\'{:s}\',{:d}".format(ext[0], ext[1])
+
+    elif isinstance(ext, int):
+        return "{:d}".format(ext)
+
+    elif isinstance(ext, str):
+        if default_extver is None:
+            extver = ''
+        else:
+            extver = '{:d}'.format(default_extver)
+
+        if compact:
+            return "{:s}{:s}".format(ext, extver)
+        else:
+            return "\'{:s}\',{:s}".format(ext, extver)
+
+    else:
+        raise TypeError("Unexpected extension type.")
+
+
+#
+# The following functions are copied from drizzlepac.updatehdr
+#
+def update_from_shiftfile(shiftfile, wcsname=None, force=False):
+    """
+    Update headers of all images specified in shiftfile with shifts
+    from shiftfile.
+
+    Parameters
+    ----------
+    shiftfile : str
+        Filename of shiftfile.
+
+    wcsname : str
+        Label to give to new WCS solution being created by this fit. If
+        a value of None is given, it will automatically use 'TWEAK' as the
+        label. [Default =None]
+
+    force : bool
+        Update header even though WCS already exists with this solution or
+        wcsname? [Default=False]
+
+    """
+    with open(fileutil.osfn(shiftfile)) as f:
+        lines = f.readlines()
+
+    refimage = None
+    shift_info = {}
+
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+
+        if refimage is not None and ('refimage' in line or
+                                     'reference' in line):
+            refimage = (line.split(':')[-1]).strip()
+            idx = refimage.find('[wcs]')
+            if idx >= 0:
+                refimage = refimage[:idx].lstrip()
+            continue
+
+        cols = list(map(str.strip, line.split()))
+
+        if len(cols) not in [5, 7]:
+            raise ValueError("Unsupported shift file format: invalid number "
+                             "of columns.")
+
+        shift_info[cols[0]] = {
+            k: float(v) for k, v in zip(_SHIFT_COLNAMES, cols[1:])
+        }
+
+    for filename, pars in shift_info:
+        updatewcs_with_shift(filename, refimage, wcsname=wcsname,
+                             force=force, **pars)
+
+
+def updatewcs_with_shift(image, reference, wcsname='TWEAK', reusename=False,
+                         fitgeom='rscale', rot=0.0, scale=1.0,
+                         xsh=0.0, ysh=0.0, fit=None, xrms=None, yrms=None,
+                         verbose=False, force=False, sciext='SCI'):
+    """
+    Update the SCI headers in 'image' based on the fit provided as determined
+    in the WCS specified by 'reference'.  The fit should be a 2-D matrix as
+    generated for use with 'make_vector_plot()'.
+
+    Notes
+    -----
+    The algorithm used to apply the provided fit solution to the image
+    involves applying the following steps to the WCS of each of the
+    input image's chips:
+
+    1. compute RA/Dec with full distortion correction for
+            reference point as (Rc_i,Dc_i)
+
+    2. find the Xc,Yc for each Rc_i,Dc_i and get the difference from the
+            CRPIX position for the reference WCS as (dXc_i,dYc_i)
+
+    3. apply fit (rot&scale) to (dXc_i,dYc_i) then apply shift, then add
+            CRPIX back to get new (Xcs_i,Ycs_i) position
+
+    4. compute (Rcs_i,Dcs_i) as the sky coordinates for (Xcs_i,Ycs_i)
+
+    5. compute delta of (Rcs_i-Rc_i, Dcs_i-Dcs_i) as (dRcs_i,dDcs_i)
+
+    6. apply the fit to the chip's undistorted CD matrix, the apply linear
+            distortion terms back in to create a new CD matrix
+
+    7. add (dRcs_i,dDcs_i) to CRVAL of the reference chip's WCS
+
+    8. update header with new WCS values
+
+    Parameters
+    ----------
+    image : str or PyFITS.HDUList object
+        Filename, or PyFITS object, of image with WCS to be updated.
+        All extensions with EXTNAME matches the value of the 'sciext'
+        parameter value (by default, all 'SCI' extensions) will be updated.
+
+    reference : str
+        Filename of image/headerlet (FITS file) which contains the WCS
+        used to define the tangent plane in which all the fit parameters
+        (shift, rot, scale) were measured.
+
+    wcsname : str, None, optional
+        Label to give to new WCS solution being created by this fit. If
+        a value of None is given, it will automatically use 'TWEAK' as the
+        label.
+        [Default =None]
+
+    reusename : bool
+        User can specify whether or not to over-write WCS with same name.
+        [Default: False]
+
+    rot : float
+        Amount of rotation measured in fit to be applied.
+        [Default=0.0]
+
+    scale : float
+        Amount of scale change measured in fit to be applied.
+        [Default=1.0]
+
+    xsh : float
+        Offset in X pixels from defined tangent plane to be applied to image.
+        [Default=0.0]
+
+    ysh : float
+        Offset in Y pixels from defined tangent plane to be applied to image.
+        [Default=0.0]
+
+    fit : arr
+        Linear coefficients for fit
+        [Default = None]
+
+    xrms : float
+        RMS of fit in RA (in decimal degrees) that will be recorded as
+        CRDER1 in WCS and header
+        [Default = None]
+
+    yrms : float
+        RMS of fit in Dec (in decimal degrees) that will be recorded as
+        CRDER2 in WCS and header
+        [Default = None]
+
+    verbose : bool
+        Print extra messages during processing? [Default=False]
+
+    force : bool
+        Update header even though WCS already exists with this solution or
+        wcsname? [Default=False]
+
+    sciext : string
+        Value of FITS EXTNAME keyword for extensions with WCS headers to
+        be updated with the fit values. [Default='SCI']
+
+    """
+    # if input reference is a ref_wcs file from tweakshifts, use it
+    if isinstance(reference, wcsutil.HSTWCS) or isinstance(reference, pywcs.WCS):
+        wref = reference
+    else:
+        refimg = fits.open(reference, memmap=False)
+        wref = None
+        for extn in refimg:
+            if 'extname' in extn.header and extn.header['extname'] == 'WCS':
+                wref = pywcs.WCS(refimg['wcs'].header)
+                break
+        refimg.close()
+        # else, we have presumably been provided a full undistorted image
+        # as a reference, so use it with HSTWCS instead
+        if wref is None:
+            wref = wcsutil.HSTWCS(reference)
+
+    if isinstance(image, fits.HDUList):
+        open_image = False
+        filename = image.filename()
+        if image.fileinfo(0)['filemode'] == 'update':
+            image_update = True
+        else:
+            image_update = False
+    else:
+        open_image = True
+        filename = image
+        image_update = None
+
+    # Now that we are sure we have a good reference WCS to use,
+    # continue with the update
+    logstr = "....Updating header for {:s}...".format(filename)
+    if verbose:
+        print("\n{:s}\n".format(logstr))
+    else:
+        logger.info(logstr)
+
+    # reset header WCS keywords to original (OPUS generated) values
+    extlist = get_ext_list(image, extname='SCI')
+    if extlist:
+        if image_update:
+            # Create initial WCSCORR extension
+            wcscorr.init_wcscorr(image, force=force)
+    else:
+        extlist = [0]
+
+    # insure that input PRIMARY WCS has been archived before overwriting
+    # with new solution
+    if open_image:
+        fimg = fits.open(image, mode='update', memmap=False)
+    else:
+        fimg = image
+
+    # Process MEF images...
+    for ext in extlist:
+        logstr = "Processing {:s}[{:s}]".format(fimg.filename(),
+                                                ext2str(ext))
+        if verbose:
+            print("\n{:s}\n".format(logstr))
+        else:
+            logger.info(logstr)
+        chip_wcs = wcsutil.HSTWCS(fimg, ext=ext)
+
+        update_refchip_with_shift(chip_wcs, wref, fitgeom=fitgeom,
+                    rot=rot, scale=scale, xsh=xsh, ysh=ysh,
+                    fit=fit, xrms=xrms, yrms=yrms)
+
+        # Update FITS file with newly updated WCS for this chip
+        extnum = fimg.index(fimg[ext])
+        update_wcs(fimg, extnum, chip_wcs, wcsname=wcsname,
+                   reusename=reusename, verbose=verbose)
+
+    if open_image:
+        fimg.close()
+
+
+def linearize(wcsim, wcsima, wcsref, imcrpix, f, shift, hx=1.0, hy=1.0):
+    """ linearization using 5-point formula for first order derivative """
+    x0 = imcrpix[0]
+    y0 = imcrpix[1]
+    p = np.asarray([[x0, y0],
+                    [x0 - hx, y0],
+                    [x0 - hx * 0.5, y0],
+                    [x0 + hx * 0.5, y0],
+                    [x0 + hx, y0],
+                    [x0, y0 - hy],
+                    [x0, y0 - hy * 0.5],
+                    [x0, y0 + hy * 0.5],
+                    [x0, y0 + hy]],
+                   dtype=np.float64)
+    # convert image coordinates to reference image coordinates:
+    p = wcsref.wcs_world2pix(wcsim.wcs_pix2world(p, 1), 1).astype(np.longdouble)
+    # apply linear fit transformation:
+    p = np.dot(f, (p - shift).T).T
+    # convert back to image coordinate system:
+    p = wcsima.wcs_world2pix(
+        wcsref.wcs_pix2world(p.astype(np.float64), 1), 1).astype(np.longdouble)
+
+    # derivative with regard to x:
+    u1 = ((p[1] - p[4]) + 8 * (p[3] - p[2])) / (6 * hx)
+    # derivative with regard to y:
+    u2 = ((p[5] - p[8]) + 8 * (p[7] - p[6])) / (6 * hy)
+
+    return (np.asarray([u1, u2]).T, p[0])
+
+
+def buildFitMatrix(rot, scale=1):
+    if hasattr(rot, '__iter__'):
+        rx = rot[0]
+        ry = rot[1]
+    else:
+        rx = float(rot)
+        ry = rx
+    if hasattr(scale, '__iter__'):
+        sx = scale[0]
+        sy = scale[1]
+    else:
+        sx = float(scale)
+        sy = sx
+    m = np.array(
+        [
+            [sx * np.cos(np.deg2rad(rx)), -sx * np.sin(np.deg2rad(rx))],
+            [sy * np.sin(np.deg2rad(ry)), sy * np.cos(np.deg2rad(ry))]
+        ]
+    )
+    return m
+
+
+def update_refchip_with_shift(chip_wcs, wcslin, fitgeom='rscale',
+                              rot=0.0, scale=1.0, xsh=0.0, ysh=0.0,
+                              fit=None, xrms=None, yrms=None):
+    """ Compute the matrix for the scale and rotation correction
+
+    Parameters
+    ----------
+    chip_wcs: wcs object
+        HST of the input image
+    wcslin: wcs object
+        Reference WCS from which the offsets/rotations are determined
+    fitgeom: str
+        NOT USED
+    rot : float
+        Amount of rotation measured in fit to be applied.
+        [Default=0.0]
+    scale : float
+        Amount of scale change measured in fit to be applied.
+        [Default=1.0]
+    xsh : float
+        Offset in X pixels from defined tangent plane to be applied to image.
+        [Default=0.0]
+    ysh : float
+        Offset in Y pixels from defined tangent plane to be applied to image.
+        [Default=0.0]
+    fit : arr
+        Linear coefficients for fit
+        [Default = None]
+    xrms : float
+        RMS of fit in RA (in decimal degrees) that will be recorded as
+        CRDER1 in WCS and header
+        [Default = None]
+    yrms : float
+        RMS of fit in Dec (in decimal degrees) that will be recorded as
+        CRDER2 in WCS and header
+        [Default = None]
+        """
+    # compute the matrix for the scale and rotation correction
+    if fit is None:
+        fit = buildFitMatrix(rot, scale)
+
+    shift = np.asarray([xsh, ysh]) - np.dot(wcslin.wcs.crpix, fit) + wcslin.wcs.crpix
+
+    fit = np.linalg.inv(fit).T
+
+    cwcs = chip_wcs.deepcopy()
+    cd_eye = np.eye(chip_wcs.wcs.cd.shape[0], dtype=np.longdouble)
+    zero_shift = np.zeros(2, dtype=np.longdouble)
+
+    naxis1, naxis2 = chip_wcs.pixel_shape
+
+    # estimate precision necessary for iterative processes:
+    maxiter = 100
+    crpix2corners = np.dstack([i.flatten() for i in np.meshgrid(
+        [1, naxis1], [1, naxis2])])[0] - chip_wcs.wcs.crpix
+    maxUerr = 1.0e-5 / np.amax(np.linalg.norm(crpix2corners, axis=1))
+
+    # estimate step for numerical differentiation. We need a step
+    # large enough to avoid rounding errors and small enough to get a
+    # better precision for numerical differentiation.
+    # TODO: The logic below should be revised at a later time so that it
+    # better takes into account the two competing requirements.
+    hx = max(1.0, min(20.0, (chip_wcs.wcs.crpix[0] - 1.0) / 100.0,
+                      (naxis1 - chip_wcs.wcs.crpix[0]) / 100.0))
+    hy = max(1.0, min(20.0, (chip_wcs.wcs.crpix[1] - 1.0) / 100.0,
+                      (naxis2 - chip_wcs.wcs.crpix[1]) / 100.0))
+
+    # compute new CRVAL for the image WCS:
+    crpixinref = wcslin.wcs_world2pix(
+        chip_wcs.wcs_pix2world([chip_wcs.wcs.crpix], 1), 1)
+    crpixinref = np.dot(fit, (crpixinref - shift).T).T
+    chip_wcs.wcs.crval = wcslin.wcs_pix2world(crpixinref, 1)[0]
+    chip_wcs.wcs.set()
+
+    # initial approximation for CD matrix of the image WCS:
+    (U, u) = linearize(cwcs, chip_wcs, wcslin, chip_wcs.wcs.crpix,
+                       fit, shift, hx=hx, hy=hy)
+    err0 = np.amax(np.abs(U - cd_eye)).astype(np.float64)
+    chip_wcs.wcs.cd = np.dot(chip_wcs.wcs.cd.astype(np.longdouble), U).astype(np.float64)
+    chip_wcs.wcs.set()
+
+    # NOTE: initial solution is the exact mathematical solution (modulo numeric
+    # differentiation). However, e.g., due to rounding errors, approximate
+    # numerical differentiation, the solution may be improved by performing
+    # several iterations. The next step will try to perform
+    # fixed-point iterations to "improve" the solution
+    # but this is not really required.
+
+    # Perform fixed-point iterations to improve the approximation
+    # for CD matrix of the image WCS (actually for the U matrix).
+    for i in range(maxiter):
+        (U, u) = linearize(chip_wcs, chip_wcs, wcslin, chip_wcs.wcs.crpix,
+                           cd_eye, zero_shift, hx=hx, hy=hy)
+        err = np.amax(np.abs(U - cd_eye)).astype(np.float64)
+        if err > err0:
+            break
+        chip_wcs.wcs.cd = np.dot(chip_wcs.wcs.cd, U).astype(np.float64)
+        chip_wcs.wcs.set()
+        if err < maxUerr:
+            break
+        err0 = err
+
+    if xrms is not None:
+        chip_wcs.wcs.crder = np.array([xrms, yrms])
+
+
+###
+# Header keyword prefix related archive functions
+###
+def update_wcs(image, extnum, new_wcs, wcsname="", reusename=False, verbose=False):
+    """
+    Updates the WCS of the specified extension number with the new WCS
+    after archiving the original WCS.
+
+    The value of 'new_wcs' needs to be the full
+    HSTWCS object.
+
+    Parameters
+    ----------
+    image : str
+        Filename of image with WCS that needs to be updated
+
+    extnum : int
+        Extension number for extension with WCS to be updated/replaced
+
+    new_wcs : object
+        Full HSTWCS object which will replace/update the existing WCS
+
+    wcsname : str
+        Label to give newly updated WCS
+
+    reusename : bool
+        User can choose whether to over-write WCS with same name or not.
+        [Default: False]
+
+    verbose : bool, int
+        Print extra messages during processing? [Default: False]
+
+    """
+    # Start by insuring that the correct value of 'orientat' has been computed
+    new_wcs.setOrient()
+
+    if isinstance(image, fits.HDUList):
+        close_file = False
+        fname = image.filename()
+    else:
+        fname = image
+        image = fits.open(image, mode='update', memmap=False)
+        close_file = True
+
+    hdr = image[extnum].header
+
+    # Name of the updated primary WCS
+    if is_blank(wcsname):
+        wcsname = 'TWEAK'
+
+    # Auto-rename old primary WCS when archiving it if an alternate WCS with
+    # the same name already exists:
+    if 'WCSNAME' in hdr:
+        pri_wcsname = hdr['WCSNAME']
+        pri_wcsname_u = pri_wcsname.upper()
+    else:
+        pri_wcsname = None
+        pri_wcsname_u = None
+
+    if pri_wcsname_u == wcsname.upper():
+        if not reusename:
+            raise ValueError(
+                f"WCSNAME '{wcsname}' already present in '{fname}'. A unique "
+                "value for the 'wcsname' parameter needs to be specified."
+            )
+    elif close_file or image.fileinfo(0) is None or image.fileinfo(0)['filemode'] == 'update':
+        altwcs.archive_wcs(image, [extnum], wcsname=pri_wcsname, mode=altwcs.ArchiveMode.AUTO_RENAME)
+
+    # Update Primary WCS:
+    try:
+        logstr = f'Updating header for {image.filename()}[{extnum}]'
+        if verbose:
+            print(logstr)
+            logger.info('    with WCS of')
+            new_wcs.printwcs()
+            print("WCSNAME  : ", wcsname)
+        else:
+            logger.info(logstr)
+
+        wcs_hdr = new_wcs.wcs2header(idc2hdr=new_wcs.idcscale is not None, relax=True)
+        wcs_hdr.set('WCSNAME', wcsname, before=0)
+        wcs_hdr.set('WCSTYPE', interpret_wcsname_type(wcsname), after=0)
+        wcs_hdr.set('ORIENTAT', new_wcs.orientat, after=len(wcs_hdr))
+        hdr.update(wcs_hdr)
+        if 'nextend' in image[0].header:
+            image[0].header['nextend'] = len(image) - 1
+
+    finally:
+        if close_file:
+            image.close()
+
+def interpret_wcsname_type(wcsname):
+    """Interpret WCSNAME as a standardized human-understandable description """
+    wcstype = ''
+    fit_terms = {'REL': 'relatively aligned to {}',
+                 'IMG': 'aligned image-by-image to {}',
+                 'EVM': 'aligned by visit-exposures to {}',
+                 'SVM': 'aligned by visit to {}'}
+    post_fit = 'a posteriori solution '
+    default_fit = 'a priori solution based on {}'
+    base_terms = {'IDC': 'undistorted ',
+                  'OPU': 'pipeline default '}
+    no_fit = 'not aligned'
+
+    if wcsname is None:
+        return no_fit
+
+    wcsname = wcsname.upper()  # make this comparison case-insensitive
+    wcsname_list = wcsname.split('-')
+    wcsname_term = wcsname_list[0][:3]
+    if wcsname_term not in base_terms:
+        wcstype = 'user-defined'  # Set to user-defined default
+        return wcstype
+
+    # Interpret base terms
+    wcstype += base_terms[wcsname_term]
+
+    # Interpret fit term (if any)
+    fit_term = wcsname_list[1] if len(wcsname_list) > 1 else None
+
+    if len(wcsname_list) == 1:
+        wcstype += no_fit
+    else:
+        if 'FIT' not in fit_term:
+            wcstype += default_fit.format(fit_term)
+        else:
+            wcstype += post_fit
+            postfit_type = fit_term.split('_')
+            wcstype += fit_terms[postfit_type[1]].format(postfit_type[2])
+    return wcstype

--- a/stwcs/wcsutil/altwcs.py
+++ b/stwcs/wcsutil/altwcs.py
@@ -64,7 +64,7 @@ def archiveWCS(fname, ext, wcskey=" ", wcsname=" ", reusekey=False):
         to get a key from WCSNAME value
     wcsname : string
         Name of alternate WCS description
-    reusekey : boolean
+    reusekey : bool
         if True - overwrites a WCS with the same key
 
     Examples

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -254,7 +254,7 @@ def find_headerlet_HDUs(fobj, hdrext=None, hdrname=None, distname=None,
         If False, all extension indices returned if hdrext, hdrname and distname
         are all None. If True and hdrext, hdrname, and distname are all None,
         raise an Exception requiring one to be specified.
-    logging : boolean
+    logging : bool
              enable logging to a file called headerlet.log
     logmode : 'w' or 'a'
              log file open mode
@@ -585,7 +585,7 @@ def extract_headerlet(filename, output, extnum=None, hdrname=None,
     clobber: bool
         If output file already exists, this parameter specifies whether or not
         to overwrite that file [Default: False]
-    logging: boolean
+    logging: bool
              enable logging to a file
 
     """
@@ -720,7 +720,7 @@ def write_headerlet(filename, hdrname, output=None, sciext='SCI',
     clobber: bool
         If output file already exists, this parameter specifies whether or not
         to overwrite that file [Default: False]
-    logging: boolean
+    logging: bool
          enable file logging
     """
 
@@ -919,7 +919,7 @@ def create_headerlet(filename, sciext='SCI', hdrname=None, destim=None,
             Number of sources used in the new solution fit
     catalog: string (optional)
             Astrometric catalog used for headerlet solution
-    logging: boolean
+    logging: bool
             enable file logging
     logmode: 'w' or 'a'
             log file open mode
@@ -1144,15 +1144,15 @@ def apply_headerlet_as_primary(filename, hdrlet, attach=True, archive=True,
              File name(s) of science observation whose WCS solution will be updated
     hdrlet: string or list of strings
              Headerlet file(s), must match 1-to-1 with input filename(s)
-    attach: boolean
+    attach: bool
             True (default): append headerlet to FITS file as a new extension.
-    archive: boolean
+    archive: bool
             True (default): before updating, create a headerlet with the
             WCS old solution.
-    force: boolean
+    force: bool
             If True, this will cause the headerlet to replace the current PRIMARY
             WCS even if it has a different distortion model. [Default: False]
-    logging: boolean
+    logging: bool
             enable file logging
     logmode: 'w' or 'a'
              log file open mode
@@ -1185,7 +1185,7 @@ def apply_headerlet_as_alternate(filename, hdrlet, attach=True, wcskey=None,
              File name(s) of science observation whose WCS solution will be updated
     hdrlet: string or list of strings
              Headerlet file(s), must match 1-to-1 with input filename(s)
-    attach: boolean
+    attach: bool
           flag indicating if the headerlet should be attached as a
           HeaderletHDU to fobj. If True checks that HDRNAME is unique
           in the fobj and stops if not.
@@ -1196,7 +1196,7 @@ def apply_headerlet_as_alternate(filename, hdrlet, attach=True, wcskey=None,
           Name to be assigned to this alternate WCS
           WCSNAME is a required keyword in a Headerlet but this allows the
           user to change it as desired.
-    logging: boolean
+    logging: bool
           enable file logging
     logmode: 'a' or 'w'
     """
@@ -1227,7 +1227,7 @@ def attach_headerlet(filename, hdrlet, logging=False, logmode='a'):
             science file(s) to which the headerlet should be applied
     hdrlet: string, Headerlet object or list of strings or Headerlet objects
             string representing a headerlet file(s), must match 1-to-1 input filename(s)
-    logging: boolean
+    logging: bool
             enable file logging
     logmode: 'a' or 'w'
     """
@@ -1274,7 +1274,7 @@ def delete_headerlet(filename, hdrname=None, hdrext=None, distname=None,
         tuple has the form ('HDRLET', 1)
     distname: string or None
         distortion model as specified in the DISTNAME keyword
-    logging: boolean
+    logging: bool
              enable file logging
     logmode: 'a' or 'w'
     """
@@ -1313,7 +1313,7 @@ def _delete_single_headerlet(filename, hdrname=None, hdrext=None, distname=None,
         tuple has the form ('HDRLET', 1)
     distname: string or None
         distortion model as specified in the DISTNAME keyword
-    logging: boolean
+    logging: bool
              enable file logging
     logmode: 'a' or 'w'
     """
@@ -1445,16 +1445,16 @@ def restore_from_headerlet(filename, hdrname=None, hdrext=None, archive=True,
         HDRNAME keyword of HeaderletHDU
     hdrext: int or tuple
         Headerlet extension number of tuple ('HDRLET',2)
-    archive: boolean (default: True)
+    archive: bool (default: True)
         When the distortion model in the headerlet is the same as the distortion model of
         the science file, this flag indicates if the primary WCS should be saved as an alternate
         nd a headerlet extension.
         When the distortion models do not match this flag indicates if the current primary and
         alternate WCSs should be archived as headerlet extensions and alternate WCS.
-    force: boolean (default:False)
+    force: bool (default:False)
         When the distortion models of the headerlet and the primary do not match, and archive
         is False, this flag forces an update of the primary.
-    logging: boolean
+    logging: bool
            enable file logging
     logmode: 'a' or 'w'
     """
@@ -1572,11 +1572,11 @@ def restore_all_with_distname(filename, distname, primary, archive=True,
         if int - a fits extension
         if string - HDRNAME
         if None - use first HeaderletHDU
-    archive: boolean (default True)
+    archive: bool (default True)
         flag indicating if HeaderletHDUs should be created from the
         primary and alternate WCSs in fname before restoring all matching
         headerlet extensions
-    logging: boolean
+    logging: bool
          enable file logging
     logmode: 'a' or 'w'
     """
@@ -1727,7 +1727,7 @@ def archive_as_headerlet(filename, hdrname, sciext='SCI',
             to the headerlet PRIMARY header
             If filename is specified, it will format and attach all text from
             that file as the history.
-    logging: boolean
+    logging: bool
             enable file folling
     logmode: 'w' or 'a'
              log file open mode
@@ -1807,7 +1807,7 @@ class Headerlet(fits.HDUList):
                 List of HDUs to be used to create the headerlet object itself
         file:  string
                 File-like object from which HDUs should be read
-        logging: boolean
+        logging: bool
                  enable file logging
         logmode: 'w' or 'a'
                 for internal use only, indicates whether the log file
@@ -1877,11 +1877,11 @@ class Headerlet(fits.HDUList):
         ----------
         fobj: string, HDUList
               science file to which the headerlet should be applied
-        attach: boolean
+        attach: bool
               flag indicating if the headerlet should be attached as a
               HeaderletHDU to fobj. If True checks that HDRNAME is unique
               in the fobj and stops if not.
-        archive: boolean (default is True)
+        archive: bool (default is True)
               When the distortion model in the headerlet is the same as the
               distortion model of the science file, this flag indicates if
               the primary WCS should be saved as an alternate and a headerlet
@@ -1889,7 +1889,7 @@ class Headerlet(fits.HDUList):
               When the distortion models do not match this flag indicates if
               the current primary and alternate WCSs should be archived as
               headerlet extensions and alternate WCS.
-        force: boolean (default is False)
+        force: bool (default is False)
               When the distortion models of the headerlet and the primary do
               not match, and archive is False this flag forces an update
               of the primary
@@ -2132,7 +2132,7 @@ class Headerlet(fits.HDUList):
         ----------
         fobj: string, HDUList
               science file/HDUList to which the headerlet should be applied
-        attach: boolean
+        attach: bool
               flag indicating if the headerlet should be attached as a
               HeaderletHDU to fobj. If True checks that HDRNAME is unique
               in the fobj and stops if not.
@@ -2454,7 +2454,7 @@ class Headerlet(fits.HDUList):
                 provide a value for DESTIM keyword
         hdrname: string (optional)
                 provide a value for HDRNAME keyword
-        clobber: boolean
+        clobber: bool
                 a flag which allows to overwrte an existing file
         """
         if not destim or not hdrname:

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1784,7 +1784,7 @@ def archive_as_headerlet(filename, hdrname, sciext='SCI',
         Headerlet with hdrname %s already archived for WCS %s
         No new headerlet appended to %s .
         """ % (hdrname, wcsname, fname)
-        logger.critical(message)
+        logger.warning(message)
 
     if close_fobj:
         fobj.close()

--- a/stwcs/wcsutil/mosaic.py
+++ b/stwcs/wcsutil/mosaic.py
@@ -31,7 +31,7 @@ def vmosaic(fnames, outwcs=None, ref_wcs=None, ext=None, extname=None, undistort
               Can be a list of integers or tuples representing FITS extensions
     extname: string
               the value of the EXTNAME keyword for the extensions to be used in the mosaic
-    undistort: boolean (default: True)
+    undistort: bool (default: True)
                undistort (or not) the output WCS
     wkey:   string
               default: 'V'
@@ -44,7 +44,7 @@ def vmosaic(fnames, outwcs=None, ref_wcs=None, ext=None, extname=None, undistort
     plot:   boolean
               if True and matplotlib is installed will make a plot of the tangent plane
               and the location of the input observations.
-    clobber: boolean
+    clobber: bool
               This covers the case when an alternate WCS with the requested key
               already exists in the header of the input files.
               if clobber is True, it will be overwritten

--- a/stwcs/wcsutil/wcsdiff.py
+++ b/stwcs/wcsutil/wcsdiff.py
@@ -26,7 +26,7 @@ def is_wcs_identical(scifile, file2, sciextlist, fextlist, scikey=" ",
              alternate WCS key in scifile
     file2key: string
              alternate WCS key in file2
-    verbose: boolean
+    verbose: bool
              True: print to stdout
 
     Notes


### PR DESCRIPTION
These changes update the 'updatewcs' task so that when querying the astrometry database, only those WCSs with the same IDCTAB as specified in the image header will be added.  If there are no WCSs in the database because the IDCTAB is new, then it will create a new headerlet based on the new IDCTAB WCS, then compute a new _a priori_ WCS using offsets from the guide star webservice.  

In addition, a new parameter was added to 'updatewcs' to control what WCSs from the database get appended to the file.  By default, only those with the same IDCTAB are added, however, it can be turned on so that ALL WCSs get appended.  

This addresses the issues described in #169.