### PR TITLE
Remove duplicate headerlet extensions in updatewcs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@
 
  - Add new parameter to ``updatewcs`` to specify whether or not to
    remove duplicate headerlet extensions from the FITS file when updating
-   the image using the astrometry database. [#171]
+   the image using the astrometry database. [#172]
 
 1.6.1 (2020-12-09)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@
    WCSs appended to the file to only those based on the same IDCTAB as
    specified in the image header. [#170]
 
+ - Add new parameter to ``updatewcs`` to specify whether or not to
+   remove duplicate headerlet extensions from the FITS file when updating
+   the image using the astrometry database. [#171]
 
 1.6.1 (2020-12-09)
 ------------------

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -40,6 +40,9 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
 
     Basic WCS keywords are updated in the process and new keywords (following WCS
     Paper IV and the SIP convention) as well as new extensions are added to the science files.
+    Duplicate HeaderletHDU extensions (each containing a separate WCS) can also be deleted
+    from the file as well.  These duplicates generally are unintended, but if left in place,
+    they can cause an Exception to be thrown when the user works with these extensions later.
 
 
     Examples
@@ -86,9 +89,7 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
               This parameter only gets used if ``use_db=True`` to remove any
               duplicate headerlet extensions.  These extensions contain WCS
               solutions that are identical to the WCS found in other
-              extensions of the image.  The duplications typically occur
-              through errors in the code, but will cause the headerlet functions
-              to fail if left in place.
+              extensions of the image.
     """
     if not verbose:
         logger.setLevel(100)

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -82,7 +82,7 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
               to the file.  If True, all solutions get appended.  If False,
               only solutions based on the IDCTAB from the file's PRIMARY
               header will be appended.
-    remove_duplicates : bool
+    remove_duplicates : bool, optional
               This parameter only gets used if ``use_db=True`` to remove any
               duplicate headerlet extensions.  These extensions contain WCS
               solutions that are identical to the WCS found in other

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -84,7 +84,7 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
               header will be appended.
     remove_duplicates : bool
               This parameter only gets used if `use_db=True` to remove any
-              duplicate headerlet extensions.   These extension contain WCS
+              duplicate headerlet extensions.  These extensions contain WCS
               solutions that are identical to the WCS found in other
               extensions of the image.  The duplications typically occur
               through errors in the code, but will cause the headerlet functions

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -83,7 +83,7 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
               only solutions based on the IDCTAB from the file's PRIMARY
               header will be appended.
     remove_duplicates : bool
-              This parameter only gets used if `use_db=True` to remove any
+              This parameter only gets used if ``use_db=True`` to remove any
               duplicate headerlet extensions.  These extensions contain WCS
               solutions that are identical to the WCS found in other
               extensions of the image.  The duplications typically occur

--- a/stwcs/updatewcs/__init__.py
+++ b/stwcs/updatewcs/__init__.py
@@ -30,7 +30,8 @@ atexit.register(logging.shutdown)
 warnings.filterwarnings("ignore", message="^Some non-standard WCS keywords were excluded:", module="astropy.wcs")
 
 def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
-              checkfiles=True, verbose=False, use_db=True, all_wcs=False):
+              checkfiles=True, verbose=False, use_db=True,
+              all_wcs=False, remove_duplicates=True):
     """
 
     Updates HST science files with the best available calibration information.
@@ -75,13 +76,19 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
               If True, attempt to add astrometric solutions from the
               MAST astrometry database.
               Default value is True.
-
     all_wcs : bool
               This parameter only gets used if `use_db=True` to control
               what WCS solutions from the Astrometry database gets appended
               to the file.  If True, all solutions get appended.  If False,
               only solutions based on the IDCTAB from the file's PRIMARY
               header will be appended.
+    remove_duplicates : bool
+              This parameter only gets used if `use_db=True` to remove any
+              duplicate headerlet extensions.   These extension contain WCS
+              solutions that are identical to the WCS found in other
+              extensions of the image.  The duplications typically occur
+              through errors in the code, but will cause the headerlet functions
+              to fail if left in place.
     """
     if not verbose:
         logger.setLevel(100)
@@ -143,7 +150,8 @@ def updatewcs(input, vacorr=True, tddcorr=True, npolcorr=True, d2imcorr=True,
         if use_db:
             # Add any new astrometry solutions available from
             #  an accessible astrometry web-service
-            astrometry.updateObs(f, all_wcs=all_wcs)
+            astrometry.updateObs(f, all_wcs=all_wcs,
+                                    remove_duplicates=remove_duplicates)
 
         if toclose:
             f.close()

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -263,6 +263,7 @@ class AstrometryDB(object):
                     if hdrnames.count(hname) > 1:
                         headerlet.delete_headerlet([obsname], hdrname=hname,
                                                     delete_all=False)
+            logger.warn(f"Duplicate headerlet with 'HDRNAME'='{hname}' found. Duplicate headerlets have been removed.")
 
         # Obtain the current primary WCS name
         current_wcsname = obsname[('sci', 1)].header['wcsname']

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -647,6 +647,9 @@ def find_gsc_offset(obsname, refframe="ICRS"):
         based on correction to guide star coordinates relative to GAIA.
         Keys: delta_x, delta_y, delta_ra, delta_dec, roll, scale, expwcs, catalog
     """
+    if isinstance(obsname, str):
+        obsname = fits.open(obsname)
+
     # check to see whether any URL has been specified as an
     # environmental variable.
     if gsss_url_envvar in os.environ:

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -256,14 +256,10 @@ class AstrometryDB(object):
                         pass
 
         if remove_duplicates:
-            hdrnames = headerlet.get_headerlet_kw_names(obsname, kw='HDRNAME')
-            hdrname_set = set(hdrnames)
-            if len(hdrnames) > len(hdrname_set):
-                for hname in hdrname_set:
-                    if hdrnames.count(hname) > 1:
-                        headerlet.delete_headerlet([obsname], hdrname=hname,
-                                                    delete_all=False)
-            logger.warn(f"Duplicate headerlet with 'HDRNAME'='{hname}' found. Duplicate headerlets have been removed.")
+            hdr_kw = headerlet.get_headerlet_kw_names(obsname, kw='HDRNAME')
+            for hname in [kwd for kwd in set(hdr_kw) if hdr_kw.count(kwd) > 1]:
+                headerlet.delete_headerlet([obsname], hdrname=hname, delete_all=False)
+                logger.warn(f"Duplicate headerlet with 'HDRNAME'='{hname}' found. Duplicate headerlets have been removed.")
 
         # Obtain the current primary WCS name
         current_wcsname = obsname[('sci', 1)].header['wcsname']

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -502,7 +502,10 @@ class AstrometryDB(object):
         idctab = obsname[0].header['IDCTAB']
         idcroot = os.path.basename(fileutil.osfn(idctab)).split('_')[0]
         # Create WCSNAME for this new a priori WCS
-        wname = 'IDC_{}-{}'.format(idcroot, pix_offsets['catalog'])
+        if pix_offsets['catalog']:
+            wname = 'IDC_{}-{}'.format(idcroot, pix_offsets['catalog'])
+        else:
+            wname = 'IDC_{}'.format(idcroot)
         # Compute and add new solution if it is not already an alternate WCS
         # Save this new WCS as a headerlet extension and separate headerlet file
         hdrname = "{}_{}".format(filename.replace('.fits', ''), wname)
@@ -622,7 +625,7 @@ def find_gsc_offset(obsname, refframe="ICRS"):
     Parameters
     ----------
     obsname : str
-        Full filename or `astropy.io.fits.HDUList` object of
+        Full filename or (preferably)`astropy.io.fits.HDUList` object of
         image to be processed.
 
     refframe : str
@@ -647,9 +650,6 @@ def find_gsc_offset(obsname, refframe="ICRS"):
         based on correction to guide star coordinates relative to GAIA.
         Keys: delta_x, delta_y, delta_ra, delta_dec, roll, scale, expwcs, catalog
     """
-    if isinstance(obsname, str):
-        obsname = fits.open(obsname)
-
     # check to see whether any URL has been specified as an
     # environmental variable.
     if gsss_url_envvar in os.environ:
@@ -658,8 +658,18 @@ def find_gsc_offset(obsname, refframe="ICRS"):
         gsss_serviceLocation = gsss_url
 
     # Initialize variables for cases where no offsets are available.
-    delta_ra = delta_dec = None
-    delta_roll = delta_scale = None
+    delta_ra = delta_dec = 0.0
+    delta_roll = 0.0
+    delta_scale = 1.0
+    dGSinputRA = dGSoutputRA = 0.0
+    dGSinputDEC = dGSoutputDEC = 0.0
+    outputCatalog = None
+
+    # Insure input is a fits.HDUList object, if originally provided as a filename(str)
+    close_obj = False
+    if isinstance(obsname, str):
+        obsname = fits.open(obsname)
+        close_obj = True
 
     if 'rootname' in obsname[0].header:
         ippssoot = obsname[0].header['rootname'].upper()
@@ -668,13 +678,13 @@ def find_gsc_offset(obsname, refframe="ICRS"):
 
     # Define what service needs to be used to get the offsets
     serviceType = "GSCConvert/GSCconvert.aspx"
-    spec_str = "REFFRAME=ICRS&IPPPSSOOT={}"
-    spec = spec_str.format(ippssoot)
+    spec_str = "REFFRAME={}&IPPPSSOOT={}"
+    spec = spec_str.format(refframe, ippssoot)
     serviceUrl = "{}/{}?{}".format(gsss_serviceLocation, serviceType, spec)
     rawcat = requests.get(serviceUrl)
     if not rawcat.ok:
-        logger.info("Problem accessing service with:\n{}".format(serviceUrl))
-        raise ValueError
+        logger.warning("Problem accessing service with:\n{}".format(serviceUrl))
+        logger.warning("  No offset found! ")
 
     if rawcat.status_code == requests.codes.ok:
         logger.info("gsReference service retrieved {}".format(ippssoot))
@@ -732,6 +742,8 @@ def find_gsc_offset(obsname, refframe="ICRS"):
                'roll': delta_roll, 'scale': delta_scale,
                'delta_ra': delta_ra, 'delta_dec': delta_dec,
                'expwcs': expwcs, 'catalog': outputCatalog}
+    if close_obj:
+        obsname.close()
 
     return offsets
 

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -258,8 +258,9 @@ class AstrometryDB(object):
         if remove_duplicates:
             hdr_kw = headerlet.get_headerlet_kw_names(obsname, kw='HDRNAME')
             for hname in [kwd for kwd in set(hdr_kw) if hdr_kw.count(kwd) > 1]:
-                headerlet.delete_headerlet([obsname], hdrname=hname, delete_all=False)
-                logger.warn(f"Duplicate headerlet with 'HDRNAME'='{hname}' found. Duplicate headerlets have been removed.")
+                headerlet.delete_headerlet([obsname], hdrname=hname, keep_first=True)
+                logger.warn(f"Duplicate headerlet with 'HDRNAME'='{hname}' found.")
+                logger.warn("Duplicate headerlets have been removed.")
 
         # Obtain the current primary WCS name
         current_wcsname = obsname[('sci', 1)].header['wcsname']

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1248,7 +1248,7 @@ def attach_headerlet(filename, hdrlet, logging=False, logmode='a'):
 
 @with_logging
 def delete_headerlet(filename, hdrname=None, hdrext=None, distname=None,
-                     delete_all=False, logging=False, logmode='w'):
+                     keep_first=False, logging=False, logmode='w'):
     """
     Deletes all HeaderletHDUs with same HDRNAME from science files
 
@@ -1274,8 +1274,8 @@ def delete_headerlet(filename, hdrname=None, hdrext=None, distname=None,
         tuple has the form ('HDRLET', 1)
     distname: string or None
         distortion model as specified in the DISTNAME keyword
-    delete_all: bool, optional
-        If False, the first specified HeaderletHDU will be NOT deleted.
+    keep_first: bool, optional
+        If True, the first matching HeaderletHDU found will be NOT deleted.
     logging: bool
              enable file logging
     logmode: 'a' or 'w'
@@ -1286,19 +1286,19 @@ def delete_headerlet(filename, hdrname=None, hdrext=None, distname=None,
     for f in filename:
         print("Deleting Headerlet from ", f)
         _delete_single_headerlet(f, hdrname=hdrname, hdrext=hdrext,
-                                 distname=distname, delete_all=delete_all,
+                                 distname=distname, keep_first=keep_first,
                                  logging=logging, logmode='a')
 
 
 def _delete_single_headerlet(filename, hdrname=None, hdrext=None, distname=None,
-                             delete_all=False, logging=False, logmode='w'):
+                             keep_first=True, logging=False, logmode='w'):
     """
-    Deletes HeaderletHDU(s) from a SINGLE science file
+    Deletes all matching HeaderletHDU(s) from a SINGLE science file
 
     Notes
     -----
     One of hdrname, hdrext or distname should be given.
-    If hdrname is given - delete a HeaderletHDU with a name HDRNAME from fobj.
+    If hdrname is given - delete all HeaderletHDUs with a name HDRNAME from fobj.
     If hdrext is given - delete HeaderletHDU in extension.
     If distname is given - deletes all HeaderletHDUs with a specific distortion model from fobj.
     Updates wcscorr
@@ -1316,9 +1316,8 @@ def _delete_single_headerlet(filename, hdrname=None, hdrext=None, distname=None,
         tuple has the form ('HDRLET', 1)
     distname: string or None
         distortion model as specified in the DISTNAME keyword
-    delete_all: bool
-        enable deletion of all headerlet extensions with the specified hdrname
-        or distname.  If False, all but the first duplicate extension will be deleted.
+    keep_first: bool, optional
+        If True, all but the first duplicate extension will be deleted.
     logging: bool
              enable file logging
     logmode: 'a' or 'w'
@@ -1351,7 +1350,7 @@ def _delete_single_headerlet(filename, hdrname=None, hdrext=None, distname=None,
 
     # delete the headerlet extension now
     hdrlet_ind.reverse()
-    del_all = 0 if delete_all else 1
+    del_all = 1 if keep_first else 0
     del_hdrlets = slice(0, len(hdrlet_ind) - del_all)
     for hdrind in hdrlet_ind[del_hdrlets]:
         del fobj[hdrind]

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1248,7 +1248,7 @@ def attach_headerlet(filename, hdrlet, logging=False, logmode='a'):
 
 @with_logging
 def delete_headerlet(filename, hdrname=None, hdrext=None, distname=None,
-                     logging=False, logmode='w'):
+                     delete_all=False, logging=False, logmode='w'):
     """
     Deletes HeaderletHDU(s) with same HDRNAME from science files
 
@@ -1274,6 +1274,9 @@ def delete_headerlet(filename, hdrname=None, hdrext=None, distname=None,
         tuple has the form ('HDRLET', 1)
     distname: string or None
         distortion model as specified in the DISTNAME keyword
+    delete_all: bool
+        enable deletion of all headerlet extensions with the specified hdrname
+        or distname.  If False, all but the first one found will be deleted.
     logging: bool
              enable file logging
     logmode: 'a' or 'w'
@@ -1284,11 +1287,12 @@ def delete_headerlet(filename, hdrname=None, hdrext=None, distname=None,
     for f in filename:
         print("Deleting Headerlet from ", f)
         _delete_single_headerlet(f, hdrname=hdrname, hdrext=hdrext,
-                                 distname=distname, logging=logging, logmode='a')
+                                 distname=distname, delete_all=delete_all,
+                                 logging=logging, logmode='a')
 
 
 def _delete_single_headerlet(filename, hdrname=None, hdrext=None, distname=None,
-                             logging=False, logmode='w'):
+                             delete_all=False, logging=False, logmode='w'):
     """
     Deletes HeaderletHDU(s) from a SINGLE science file
 
@@ -1313,6 +1317,9 @@ def _delete_single_headerlet(filename, hdrname=None, hdrext=None, distname=None,
         tuple has the form ('HDRLET', 1)
     distname: string or None
         distortion model as specified in the DISTNAME keyword
+    delete_all: bool
+        enable deletion of all headerlet extensions with the specified hdrname
+        or distname.  If False, all but the first duplicate extension will be deleted.
     logging: bool
              enable file logging
     logmode: 'a' or 'w'
@@ -1344,7 +1351,10 @@ def _delete_single_headerlet(filename, hdrname=None, hdrext=None, distname=None,
     wcscorr.delete_wcscorr_row(fobj['WCSCORR'].data, selections)
 
     # delete the headerlet extension now
-    for hdrind in hdrlet_ind:
+    hdrlet_ind.reverse()
+    del_all = 0 if delete_all else 1
+    del_hdrlets = slice(0, len(hdrlet_ind) - del_all)
+    for hdrind in hdrlet_ind[del_hdrlets]:
         del fobj[hdrind]
 
     utils.updateNEXTENDKw(fobj)

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -1250,13 +1250,13 @@ def attach_headerlet(filename, hdrlet, logging=False, logmode='a'):
 def delete_headerlet(filename, hdrname=None, hdrext=None, distname=None,
                      delete_all=False, logging=False, logmode='w'):
     """
-    Deletes HeaderletHDU(s) with same HDRNAME from science files
+    Deletes all HeaderletHDUs with same HDRNAME from science files
 
     Notes
     -----
     One of hdrname, hdrext or distname should be given.
-    If hdrname is given - delete a HeaderletHDU with a name HDRNAME from fobj.
-    If hdrext is given - delete HeaderletHDU in extension.
+    If hdrname is given - delete all HeaderletHDUs with a name HDRNAME from fobj.
+    If hdrext is given - delete specified HeaderletHDU(s) extension(s).
     If distname is given - deletes all HeaderletHDUs with a specific distortion model from fobj.
     Updates wcscorr
 
@@ -1274,9 +1274,8 @@ def delete_headerlet(filename, hdrname=None, hdrext=None, distname=None,
         tuple has the form ('HDRLET', 1)
     distname: string or None
         distortion model as specified in the DISTNAME keyword
-    delete_all: bool
-        enable deletion of all headerlet extensions with the specified hdrname
-        or distname.  If False, all but the first one found will be deleted.
+    delete_all: bool, optional
+        If False, the first specified HeaderletHDU will be NOT deleted.
     logging: bool
              enable file logging
     logmode: 'a' or 'w'


### PR DESCRIPTION
These changes fix a problem which was found when appending solutions from the astrometry database as headerlet extensions to images; namely, that there can be duplicate headerlet extensions all with the same `HDRNAME` keyword value.  These problems typically occur as a result of errors in processing, with manual updates to the images being the most prone.  However, the Drizzlepac nightly regression tests process an image which suffers from this problem after updating with all the WCS solutions from the astrometry database (most likely due to multiple entries in the database).

These changes:
- fix a bug in `wcsutil.headerlet.delete_headerlet` to allow multiple extensions to be deleted correctly 
- add a new parameter to the `updatewcs.astrometry_utils.AstrometryDB` method `updateObs()` to control whether to remove duplicate extensions or not.
- expose the new parameter `remove_duplicates` through the main `updatewcs.updatewcs()` function
