### PR TITLE
Insure Distortion Keywords Remain in the correct place in the headers

### DIFF
--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -390,11 +390,10 @@ def update_ref_files(source, dest):
               'DISTNAME': True}
 
     for key in phdukw:
+        if key not in dest:
+            phdukw[key] = False
+            continue
         try:
-            try:
-                del dest[key]
-            except:
-                pass
             dest.set(key, source[key], source.comments[key])
         except KeyError:
             phdukw[key] = False
@@ -2028,7 +2027,7 @@ class Headerlet(fits.HDUList):
                         hdrlet_extnames.append(hname_u)
 
                     altwcs.deleteWCS(fobj, sciext_list, wcskey=wcskey, wcsname=hname)
-
+        indx = fobj[0].header.index('imphttab')
         self._del_dest_WCS_ext(fobj)
         for i in range(1, numsip + 1):
             target_ext = sciext_list[i - 1]
@@ -2095,6 +2094,7 @@ class Headerlet(fits.HDUList):
                     numnpol = 2
 
             fobj[target_ext].header.update(priwcs[0].header)
+
             if sipwcs.cpdis1:
                 whdu = priwcs[('WCSDVARR', (i - 1) * numnpol + 1)].copy()
                 whdu.ver = int(self[('SIPWCS', i)].header['DP1.EXTVER'])
@@ -2115,6 +2115,7 @@ class Headerlet(fits.HDUList):
         update_versions(self[0].header, fobj[0].header)
         #refs = update_ref_files(self[0].header, fobj[0].header)
         _ = update_ref_files(self[0].header, fobj[0].header)
+
         # Update the WCSCORR table with new rows from the headerlet's WCSs
         wcscorr.update_wcscorr(fobj, self, 'SIPWCS')
 
@@ -2514,7 +2515,7 @@ class Headerlet(fits.HDUList):
         refkw = ['IDCTAB', 'NPOLFILE', 'D2IMFILE', 'SIPNAME', 'DISTNAME']
         for kw in refkw:
             try:
-                del phdu.header[kw]
+                phdu.header.set(kw, 'N/A')
             except KeyError:
                 pass
 
@@ -2554,7 +2555,7 @@ class Headerlet(fits.HDUList):
                     except KeyError:
                         pass
         try:
-            del ext.header['IDCTAB']
+            ext.header.set('IDCTAB', 'N/A')
         except KeyError:
             pass
 
@@ -2574,7 +2575,7 @@ class Headerlet(fits.HDUList):
                 del ext.header['DP%s*...' % c]
                 del ext.header[cpdis.cards[c - 1].keyword]
             del ext.header['CPERR*']
-            del ext.header['NPOLFILE']
+            ext.header.set('NPOLFILE', 'N/A')
             del ext.header['NPOLEXT']
         except KeyError:
             pass
@@ -2595,7 +2596,7 @@ class Headerlet(fits.HDUList):
                 del ext.header['D2IM%s*...' % c]
                 del ext.header[d2imdis.cards[c - 1].keyword]
             del ext.header['D2IMERR*']
-            del ext.header['D2IMFILE']
+            ext.header.set('D2IMFILE', 'N/A')
             del ext.header['D2IMEXT']
         except KeyError:
             pass

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -83,6 +83,7 @@ logger.setLevel(logging.DEBUG)
 FITS_STD_KW = ['XTENSION', 'BITPIX', 'NAXIS', 'PCOUNT',
                'GCOUNT', 'EXTNAME', 'EXTVER', 'ORIGIN',
                'INHERIT', 'DATE', 'IRAF-TLM']
+DISTORTION_KEYWORDS = ['NPOLFILE', 'IDCTAB', 'D2IMFILE', 'SIPNAME', 'DISTNAME']
 
 DEFAULT_SUMMARY_COLS = ['HDRNAME', 'WCSNAME', 'DISTNAME', 'AUTHOR', 'DATE',
                         'SIPNAME', 'NPOLFILE', 'D2IMFILE', 'DESCRIP']
@@ -383,20 +384,15 @@ def update_ref_files(source, dest):
     dest :   `astropy.io.fits.Header`
     """
     logger.info("Updating reference files")
-    phdukw = {'NPOLFILE': True,
-              'IDCTAB': True,
-              'D2IMFILE': True,
-              'SIPNAME': True,
-              'DISTNAME': True}
+    phdukw = {}
 
-    for key in phdukw:
-        if key not in dest:
-            phdukw[key] = False
-            continue
-        try:
+    for key in DISTORTION_KEYWORDS:
+        if key in dest:
             dest.set(key, source[key], source.comments[key])
-        except KeyError:
+            phdukw[key] = True
+        else:
             phdukw[key] = False
+
     return phdukw
 
 

--- a/stwcs/wcsutil/headerlet.py
+++ b/stwcs/wcsutil/headerlet.py
@@ -2027,7 +2027,6 @@ class Headerlet(fits.HDUList):
                         hdrlet_extnames.append(hname_u)
 
                     altwcs.deleteWCS(fobj, sciext_list, wcskey=wcskey, wcsname=hname)
-        indx = fobj[0].header.index('imphttab')
         self._del_dest_WCS_ext(fobj)
         for i in range(1, numsip + 1):
             target_ext = sciext_list[i - 1]


### PR DESCRIPTION
This set of changes insures that the IDCTAB, NPOLFILE and D2IMFILE keywords remain in the same part of the primary header as the rest of the calibration reference file keywords.  They reported that these keywords were ending up at the end of the primary header after distortion correction by 'updatewcs', so this PR insures that these keywords do not get moved.  