### PR TITLE
Improve handling of primary headers with extver but without extname

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 1.6.2 (Unreleased)
 ------------------
 
+- Make the code more robust when defining ``extname`` attribute of a WCS for
+  multi-extension FITS files when their primary header contains ``'EXTVER'``
+  keyword but not the ``'EXTNAME'`` keywords. [#179]
+
 - Fix a bug in ``stwcs.wcsutil.altwcs.archive_wcs`` due to which
   a ``str`` type ``ext`` would raise an exception. [#177]
 

--- a/stwcs/tests/test_hstwcs.py
+++ b/stwcs/tests/test_hstwcs.py
@@ -1,5 +1,5 @@
 from astropy.io import fits
-from ..wcsutil import hstwcs
+from stwcs.wcsutil import hstwcs, HSTWCS
 
 
 def test_radesys():
@@ -12,3 +12,13 @@ def test_radesys():
     assert hstwcs.determine_refframe(phdr) is None
     phdr['refframe'] = ' '
     assert hstwcs.determine_refframe(phdr) is None
+
+
+def test_prihdu_with_extver_no_extname():
+    hdulist = fits.HDUList([
+        fits.PrimaryHDU(header=fits.Header([('extver', 7)])),
+        fits.ImageHDU(header=fits.Header([('time', 6)]))
+    ])
+    extname = HSTWCS(hdulist).extname
+    assert extname == ('PRIMARY', 7)
+    assert hdulist[extname] is hdulist[0]

--- a/stwcs/wcsutil/hstwcs.py
+++ b/stwcs/wcsutil/hstwcs.py
@@ -156,8 +156,8 @@ class HSTWCS(WCS):
                 phdu.close()
             self.setInstrSpecKw(hdr0, ehdr)
             self.readIDCCoeffs(ehdr)
-            extname = ehdr.get('EXTNAME', '')
-            extnum = ehdr.get('EXTVER', None)
+            extname = ehdr.get('EXTNAME', 'PRIMARY' if ehdr is hdr0 else '')
+            extnum = ehdr.get('EXTVER', 1)
             self.extname = (extname, extnum)
         else:
             # create a default HSTWCS object


### PR DESCRIPTION
This PR improves reliability of the code responsible for computing `extname` property of an `HSTWCS` object when image's primary header contains `'EXTVER'` keyword but is missing `'EXTNAME'`. This will allow `astrodrizzle` to handle such files instead of currently crashing.