### PR TITLE
Convert WCSNAME to hash for HLET filename

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,8 @@
 1.7.1 (Unreleased)
 ------------------
+- Filenames for new headerlet files based on updated/new
+  IDCTABs now based on hash of WCSNAME instead of WCSNAME itself. [#183]
+
 
 1.7.0 (2021-08-10)
 ------------------

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -32,6 +32,7 @@ GSSS_WEBSERVICES_URL - URL point to user-specified web service which provides
 import os
 import sys
 import atexit
+import hashlib
 
 import requests
 from io import BytesIO
@@ -473,7 +474,8 @@ class AstrometryDB(object):
         hlet_names = [obsname[('hdrlet', e)].header['wcsname'] for e in hlet_extns]
 
         if wname not in hlet_names:
-            hdrname = "{}_{}".format(filename.replace('.fits', ''), wname)
+            wname_hash = hashlib.sha1(wname.encode()).hexdigest()[:6]
+            hdrname = "{}_{}".format(filename.replace('.fits', ''), wname_hash)
             # Create full filename for headerlet:
             hfilename = "{}_hlet.fits".format(hdrname)
             logger.info("Archiving pipeline-default WCS {} to {}".format(wname, filename))


### PR DESCRIPTION
The convention used to create the headerlet filenames for WCS solutions based on updated/new IDCTAB reference files was modified to insure the names have a shorter, constant length.  This PR does that by converting the WCSNAME keyword value used to make the headerlet filename unique into a simple SHA1 hash, then the code only uses the first 6 characters of the hash in the new filename.  

This addresses a problem the STScI archive has with the previous variable length and overly long filenames.