### PR TITLE
Avoid Exception for some new data

### DIFF
--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -470,7 +470,6 @@ class AstrometryDB(object):
         hlet_extns = headerlet.get_headerlet_kw_names(obsname, kw='EXTVER')
         # newly processed data will not have any hlet_extns, so we need to account for that
         newhlt = max(hlet_extns) + 1 if len(hlet_extns) > 0 else 1
-        newext = max(headerlet.find_headerlet_HDUs(obsname, strict=False))
         hlet_names = [obsname[('hdrlet', e)].header['wcsname'] for e in hlet_extns]
 
         if wname not in hlet_names:


### PR DESCRIPTION
Recent processing of new HST data triggered an Exception due to not getting any headerlet solutions from the astrometry database of pre-computed corrections.  This simple PR corrects the problem that triggered the Exception by removing a line of code which triggered the Exception yet whose result was never used, and in fact, got recomputed later in the same function. 

This problem originally affected pipeline processing of the single exposure ier510g5q, which was also used to not only reproduce the reported Exception, but also used to confirm that this change correctly fixes this problem with no other apparent side-effects. 