### PR TITLE
Updated changelog, pin numpy >= 2.0.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 - Manual scalar promotion of refpix['PSCALE'] from float32
   to float64 to avoid future Numpy 2.0 issues [#206].
 
-- Pin numpy min version greater than 2.0 [#214]
+- Pin numpy min version greater than 2.0 [#214] 
 
 
 1.7.3 (2024-05-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 - Manual scalar promotion of refpix['PSCALE'] from float32
   to float64 to avoid future Numpy 2.0 issues [#206].
 
-- Pin numpy min version greater than 2.0 [#213]
+- Pin numpy min version greater than 2.0 [#214]
 
 
 1.7.3 (2024-05-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,21 @@
-1.7.3 (Unreleased)
+1.7.4 (2025-01-07)
 ------------------
 
 - Manual scalar promotion of refpix['PSCALE'] from float32
   to float64 to avoid future Numpy 2.0 issues [#206].
 
-- Pin astropy min version to 5.0.4. [#191]
+- Pin numpy min version greater than 2.0 [#213]
+
+
+1.7.3 (2024-05-06)
+------------------
+  
+- Avoid Exception for some new data. [#189]
+  
+- Convert WCSNAME to hash for HLET filename. [#183]
+  
+- Pin astropy min version to 5.0.4 [#191]
+  
 
 1.7.2 (2021-11-29)
 -----------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "astropy>=5.0.4",
+    "astropy>=6.0",
     "numpy>=2.0",
     "stsci.tools>=3.6",
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.0.4",
-    "numpy",
+    "numpy>=2.0",
     "stsci.tools>=3.6",
     "requests",
     "lxml",


### PR DESCRIPTION
This PR pins numpy to at least numpy 2.0 and updates the changelog for the 1.7.4 planned release tomorrow. 