### PR TITLE
Added regression testing for python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Python 3.10
-            runs-on: ubuntu-latest
-            python-version: '3.10'
-            toxenv: py310
-
           - name: Python 3.11
             runs-on: ubuntu-latest
             python-version: 3.11
@@ -30,6 +25,11 @@ jobs:
             runs-on: ubuntu-latest
             python-version: 3.12
             toxenv: py312
+
+          - name: Python 3.13
+            runs-on: ubuntu-latest
+            python-version: 3.13
+            toxenv: py313
 
           - name: Code style checks
             runs-on: ubuntu-latest

--- a/.github/workflows/weekly_cron.yml
+++ b/.github/workflows/weekly_cron.yml
@@ -13,11 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Python 3.10
-            runs-on: ubuntu-latest
-            python-version: '3.10'
-            toxenv: py310
-
           - name: Python 3.11
             runs-on: ubuntu-latest
             python-version: 3.11
@@ -27,6 +22,11 @@ jobs:
             runs-on: ubuntu-latest
             python-version: 3.12
             toxenv: py312
+
+          - name: Python 3.13
+            runs-on: ubuntu-latest
+            python-version: 3.13
+            toxenv: py313
 
           - name: Code style checks
             runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1443](https://jira.stsci.edu/browse/HLA-1443)

<!-- describe the changes comprising this PR here -->
This PR removes regression tests for python 3.10 and adds them for python 3.13. This is done for both the weekly cron job as well as the CI for pull requests. 