### PR TITLE
HLA-1467: Add log info line to astrometry database query

### DIFF
--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -142,9 +142,6 @@ class AstrometryDB(object):
 
         if url is not None:
             self.serviceLocation = url
-            
-        logger.info("Astrometry Database URL: {}".format(
-            self.serviceLocation))
         #
         # Implement control over behavior for error conditions
         # User provided input will always take precedent
@@ -587,6 +584,7 @@ class AstrometryDB(object):
             return
 
         serviceEndPoint = self.serviceLocation + 'availability'
+        logger.info(f"AstrometryDB URL: {serviceEndPoint}")
 
         try:
             r = requests.get(serviceEndPoint, headers=self.headers)

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -142,6 +142,9 @@ class AstrometryDB(object):
 
         if url is not None:
             self.serviceLocation = url
+            
+        logger.info("Astrometry Database URL: {}".format(
+            self.serviceLocation))
         #
         # Implement control over behavior for error conditions
         # User provided input will always take precedent


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1467](https://jira.stsci.edu/browse/HLA-1467)

<!-- describe the changes comprising this PR here -->
This PR adds a log line at the first check of whether the Astrometry database is available. The line is added right before the check so that it is printed whether the astrometry databased is available or not. 

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)