### PR TITLE
HLA-1541: Fix processing with no offsets from GSC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - '*'
   pull_request:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Unreleased
 ----------
-- When the GSC web service returns no RA and DEC offsets from GAIA (0.), use default FITS WCS values.
+- When the GSC web service returns no RA and DEC offsets from GAIA,
+  use default FITS WCS values. [#225]
+
+- When computing an orthogonal CD matrix, check that ``idcscale`` exists
+  and is not ``None``. If ``idcscale`` is missing (some headerlets in
+  the Astrometry DB), compute a scale from the CD matrix. [#225]
+
+1.7.5 (2025-07-14)
+------------------
+- Work around an issue with the AStrometry DB which returns NaNs in certain cases. [#221]
 
 1.7.4 (2025-01-07)
 ------------------
@@ -8,18 +17,18 @@ Unreleased
 - Manual scalar promotion of refpix['PSCALE'] from float32
   to float64 to avoid future Numpy 2.0 issues [#206].
 
-- Pin numpy min version greater than 2.0 [#214] 
+- Pin numpy min version greater than 2.0 [#214]
 
 
 1.7.3 (2024-05-06)
 ------------------
-  
+
 - Avoid Exception for some new data. [#189]
-  
+
 - Convert WCSNAME to hash for HLET filename. [#183]
-  
+
 - Pin astropy min version to 5.0.4 [#191]
-  
+
 
 1.7.2 (2021-11-29)
 -----------------

--- a/stwcs/distortion/utils.py
+++ b/stwcs/distortion/utils.py
@@ -112,16 +112,19 @@ def make_orthogonal_cd(wcs):
         sn = np.sin(np.deg2rad(pv))
         pvmat = np.dot(np.array([[cs, sn], [-sn, cs]]), wcs.parity)
         rot = np.arctan2(pvmat[0, 1], pvmat[1, 1])
-        scale = wcs.idcscale / 3600.
 
         det = linalg.det(wcs.parity)
+        if hasattr(wcs, 'idcscale') and wcs.idcscale is not None:
+            scale = (wcs.idcscale) / 3600.  # HST pixel scale provided
+        else:
+            scale = np.sqrt(np.abs(det))  # find as sqrt(pixel area)
 
     else:
 
         det = linalg.det(cd)
 
         # find pixel scale:
-        if hasattr(wcs, 'idcscale'):
+        if hasattr(wcs, 'idcscale') and wcs.idcscale is not None:
             scale = (wcs.idcscale) / 3600.  # HST pixel scale provided
         else:
             scale = np.sqrt(np.abs(det))  # find as sqrt(pixel area)

--- a/stwcs/tests/test_astrometrydb.py
+++ b/stwcs/tests/test_astrometrydb.py
@@ -55,6 +55,7 @@ class TestAstrometryDB(object):
         assert adb.available
         del adb
 
+    @pytest.mark.skip("Need to understand why this fails and how it's supposed to work.")
     def test_default(self):
         """
         Sanity check: Insure it will run at all in default mode
@@ -65,6 +66,11 @@ class TestAstrometryDB(object):
         adb = astrometry_utils.AstrometryDB()
         adb.updateObs(self.acs_file)
         # at this point self.acs_file == self.ref_file if all worked...
+        acs = fits.open(self.acs_file)
+        ref = fits.open(self.ref_file)
+        report = diff.HDUDiff(acs[1], ref[1], ignore_keywords=['HDRNAME', 'HDRNAMEB']).report()
+        print(report)
+        assert report == ""
 
     @pytest.mark.skip("Need to understand why this fails and how it's supposed to work.")
     def test_new_obs(self):

--- a/stwcs/tests/test_updatewcs.py
+++ b/stwcs/tests/test_updatewcs.py
@@ -495,8 +495,3 @@ def test_make_orthogonal_cd(idcscale):
     w = dutils.make_orthogonal_cd(ewcs)
     cd = w.wcs.cd
     testing.assert_equal(cd * cd.T, cd.T * cd)
-
-    ewcs.idcscale = None
-    w = dutils.make_orthogonal_cd(ewcs)
-    cd = w.wcs.cd
-    testing.assert_equal(cd * cd.T, cd.T * cd)

--- a/stwcs/tests/test_updatewcs.py
+++ b/stwcs/tests/test_updatewcs.py
@@ -481,3 +481,22 @@ def test_update_stis_asn():
 
     wcsname_exp1 = fits.getval('o4k19ac3q_flt.fits','wcsname',ext=('sci',1))
     assert wcsname_exp1.startswith('IDC_')
+
+
+@pytest.mark.parametrize("idcscale", [0.5, None])
+def test_make_orthogonal_cd(idcscale):
+    ewcs = wcs.WCS(naxis=2)
+    ewcs.wcs.crval = [5.63056810618, -72.05457184278998]
+    ewcs.wcs.crpix = [2048.0, 1024.0]
+    ewcs.wcs.ctype = ["RA---TAN-SIP", "DEC--TAN-SIP"]
+    ewcs.wcs.cd = [[1.29055156992758e-05, 5.95250078565221e-06],[5.02263821027651e-06, -1.2644844109546e-05]]
+    ewcs.idcscale = idcscale
+    assert idcscale == ewcs.idcscale
+    w = dutils.make_orthogonal_cd(ewcs)
+    cd = w.wcs.cd
+    testing.assert_equal(cd * cd.T, cd.T * cd)
+
+    ewcs.idcscale = None
+    w = dutils.make_orthogonal_cd(ewcs)
+    cd = w.wcs.cd
+    testing.assert_equal(cd * cd.T, cd.T * cd)

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -664,7 +664,7 @@ def find_gsc_offset(obsname, refframe="ICRS"):
     default_delta_roll = 0.0
     default_delta_scale = 1.0
     default_dGSinputRA = default_dGSoutputRA = 0.0
-    defailt_dGSinputDEC = default_dGSoutputDEC = 0.0
+    default_dGSinputDEC = default_dGSoutputDEC = 0.0
     default_outputCatalog = None
 
     # Insure input is a fits.HDUList object, if originally provided as a filename(str)
@@ -692,10 +692,10 @@ def find_gsc_offset(obsname, refframe="ICRS"):
         delta_roll = default_delta_roll
         delta_scale = default_delta_scale
         dGSinputRA = default_dGSinputRA
-        GSinputDEC = default_GSinputDEC
+        dGSinputDEC = default_dGSinputDEC
         dGSoutputRA = default_dGSoutputRA
         dGSoutputDEC = default_dGSoutputDEC
-        outputCatalog = default_ouputCatalog
+        outputCatalog = default_outputCatalog
     if rawcat.status_code == requests.codes.ok:
         logger.info("gsReference service retrieved {}".format(ippssoot))
         refXMLtree = etree.fromstring(rawcat.content)
@@ -745,18 +745,18 @@ def find_gsc_offset(obsname, refframe="ICRS"):
         newpix = expwcs.all_world2pix(new_crval.ra.value, new_crval.dec.value, 1)
         deltaxy = expwcs.wcs.crpix - newpix  # offset from ref pixel position
         offsets = {'delta_x': deltaxy[0], 'delta_y': deltaxy[1],
-            'roll': delta_roll, 'scale': delta_scale,
-            'delta_ra': delta_ra, 'delta_dec': delta_dec,
-            'expwcs': expwcs, 'catalog': outputCatalog}
+                   'roll': delta_roll, 'scale': delta_scale,
+                   'delta_ra': delta_ra, 'delta_dec': delta_dec,
+                   'expwcs': expwcs, 'catalog': outputCatalog}
 
     else:
         logger.warning("GSC returned 0 offsets in RA, DEC for guide star")
         deltaxy = (0., 0.)
 
         offsets = {'delta_x': deltaxy[0], 'delta_y': deltaxy[1],
-                'roll': default_delta_roll, 'scale': default_delta_scale,
-                'delta_ra': default_delta_ra, 'delta_dec': default_delta_dec,
-                'expwcs': expwcs, 'catalog': default_outputCatalog}
+                   'roll': default_delta_roll, 'scale': default_delta_scale,
+                   'delta_ra': default_delta_ra, 'delta_dec': default_delta_dec,
+                   'expwcs': expwcs, 'catalog': default_outputCatalog}
     if close_obj:
         obsname.close()
     return offsets

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -687,7 +687,15 @@ def find_gsc_offset(obsname, refframe="ICRS"):
     if not rawcat.ok:
         logger.warning("Problem accessing service with:\n{}".format(serviceUrl))
         logger.warning("  No offset found! ")
-
+        delta_ra = default_delta_ra
+        delta_dec = default_delta_dec
+        delta_roll = default_delta_roll
+        delta_scale = default_delta_scale
+        dGSinputRA = default_dGSinputRA
+        GSinputDEC = default_GSinputDEC
+        dGSoutputRA = default_dGSoutputRA
+        dGSoutputDEC = default_dGSoutputDEC
+        outputCatalog = default_ouputCatalog
     if rawcat.status_code == requests.codes.ok:
         logger.info("gsReference service retrieved {}".format(ippssoot))
         refXMLtree = etree.fromstring(rawcat.content)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1541](https://jira.stsci.edu/browse/HLA-1541)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes spacetelescope/drizzlepac#2057

<!-- describe the changes comprising this PR here -->
This PR addresses
- a bug in astrometry_utils in the case when no offsets from GAIA  are returned by the GSC service and default values were not set for some of the variables. Ads a test for the bug.
- enables CI
- completes previously added tests which did not compare or have `asserts` but skips them since they fail. Filed #2058 to follow up.

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [ ] updated relevant documentation
- [x] added relevant label(s)

Passing regression tests: https://github.com/spacetelescope/RegressionTests/actions/runs/16832021076/job/47681975890