### PR TITLE
HLA-1550: Add warning when astrometry database can't be reached

### DIFF
--- a/stwcs/tests/test_updatewcs.py
+++ b/stwcs/tests/test_updatewcs.py
@@ -6,7 +6,7 @@ from astropy import wcs
 from astropy.io import fits
 from astropy.wcs import FITSFixedWarning
 from .. import updatewcs
-from ..updatewcs import apply_corrections
+from ..updatewcs import apply_corrections, astrometry_utils
 from ..distortion import utils as dutils
 from ..wcsutil import HSTWCS
 import numpy as np
@@ -499,3 +499,15 @@ def test_make_orthogonal_cd(idcscale):
     w = dutils.make_orthogonal_cd(ewcs)
     cd = w.wcs.cd
     testing.assert_equal(cd * cd.T, cd.T * cd)
+
+def test_astrometrydb_bad_gateway():
+    db = astrometry_utils.AstrometryDB(url='bad_link')
+
+@pytest.mark.xfail
+def test_astrometrydb_bad_gateway_raise_errors():
+    db = astrometry_utils.AstrometryDB(url='bad_link', raise_errors=True)
+
+@pytest.mark.xfail
+def test_astrometrydb_timeout_raise_errors():
+    db = astrometry_utils.AstrometryDB(raise_errors=True)
+    db.isAvailable(testing=True)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1550](https://jira.stsci.edu/browse/HLA-1550)

<!-- describe the changes comprising this PR here -->
This PR adds an automatic retry of the isAvailable() functionality after 60 seconds of the initial failure. I've also added a couple tests to insure that the raise_error option is functioning properly. 

To raise warnings in the code as opposed to printed warning, the environmental variable `"RAISE_PIPELINE_ERRORS"` needs to be added. 

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)