### PR TITLE
HLA-1588: Bug fix for "delta_x" undefined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+1.7.7 (2026-03-03)
+------------------
+
+- Bug fix for 'delta_x not defined'; related to GSC returning zero offsets [#243]
+
+
 1.7.6 (2026-02-03)
 ------------------
 

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -765,7 +765,6 @@ def find_gsc_offset(obsname):
         ippssoot = fileutil.buildNewRootname(obsname).upper()
 
     expwcs = build_reference_wcs(obsname)
-    delta_xy = [0.0, 0.0]
     # Initialize variables for cases where no offsets are available.
     response = {
         "delta_ra": 0.0,
@@ -779,8 +778,8 @@ def find_gsc_offset(obsname):
         "catalog": None,
         "message": "",
         "expwcs": expwcs,
-        "delta_x": delta_xy[0],
-        "delta_y": delta_xy[1],
+        "delta_x": 0.0,
+        "delta_y": 0.0,
     }
     # Define what service needs to be used to get the offsets
     serviceType = "GSCConvert/GSCconvert.aspx"
@@ -815,8 +814,8 @@ def find_gsc_offset(obsname):
                 "catalog": refXMLtree.findtext('outputCatalog'),
                 "message": message,
                 "expwcs": expwcs,
-                "delta_x": delta_xy[0],
-                "delta_y": delta_xy[1],
+                "delta_x": 0.0,
+                "delta_y": 0.0,
                 }
         else:
             # status_code == 200 but message indicates "Failure"

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -813,8 +813,10 @@ def find_gsc_offset(obsname):
                 "dGSoutputRA": float(refXMLtree.findtext('dGSoutputRA')),
                 "dGSoutputDEC": float(refXMLtree.findtext('dGSoutputDEC')),
                 "catalog": refXMLtree.findtext('outputCatalog'),
-                "expwcs": expwcs,
                 "message": message,
+                "expwcs": expwcs,
+                "delta_x": delta_xy[0],
+                "delta_y": delta_xy[1],
                 }
         else:
             # status_code == 200 but message indicates "Failure"
@@ -855,12 +857,11 @@ def find_gsc_offset(obsname):
         # Compute offset in pixels for new CRVAL
         newpix = expwcs.all_world2pix(new_crval.ra.value, new_crval.dec.value, 1)
         delta_xy = expwcs.wcs.crpix - newpix  # offset from ref pixel position
+        response["delta_x"] = delta_xy[0]
+        response["delta_y"] = delta_xy[1]
 
     else:
         logger.warning("GSC returned zero offsets in RA, DEC for guide star")
-    
-    response["delta_x"] = delta_xy[0]
-    response["delta_y"] = delta_xy[1]
 
     if close_obj:
         obsname.close()

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -854,12 +854,13 @@ def find_gsc_offset(obsname):
 
         # Compute offset in pixels for new CRVAL
         newpix = expwcs.all_world2pix(new_crval.ra.value, new_crval.dec.value, 1)
-        deltaxy = expwcs.wcs.crpix - newpix  # offset from ref pixel position
+        delta_xy = expwcs.wcs.crpix - newpix  # offset from ref pixel position
 
-        response["delta_x"] = deltaxy[0]
-        response["delta_y"] = deltaxy[1]
     else:
         logger.warning("GSC returned zero offsets in RA, DEC for guide star")
+    
+    response["delta_x"] = delta_xy[0]
+    response["delta_y"] = delta_xy[1]
 
     if close_obj:
         obsname.close()

--- a/stwcs/updatewcs/astrometry_utils.py
+++ b/stwcs/updatewcs/astrometry_utils.py
@@ -855,9 +855,9 @@ def find_gsc_offset(obsname):
 
         # Compute offset in pixels for new CRVAL
         newpix = expwcs.all_world2pix(new_crval.ra.value, new_crval.dec.value, 1)
-        delta_xy = expwcs.wcs.crpix - newpix  # offset from ref pixel position
-        response["delta_x"] = delta_xy[0]
-        response["delta_y"] = delta_xy[1]
+        deltaxy = expwcs.wcs.crpix - newpix  # offset from ref pixel position
+        response["delta_x"] = deltaxy[0]
+        response["delta_y"] = deltaxy[1]
 
     else:
         logger.warning("GSC returned zero offsets in RA, DEC for guide star")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1588](https://jira.stsci.edu/browse/HLA-1588)

<!-- describe the changes comprising this PR here -->
[#2134](https://github.com/spacetelescope/drizzlepac/issues/2134)

This PR addresses a bug where an error occurs where the WCS solution parameter `delta_x` is undefined. This happened because in the case of "_GSC returned zero offsets in RA, DEC for guide star_", the parameter wasn't being defined. This was a bug introduced with PR #227 , but that should be fix with this code change. 

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)