### PR TITLE
HLA-1587: Ignore distortion header keywords when comparing test WCS solutions 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+1.7.8 (TBD)
+-----------
+
+- Bug fix addressing astropy wcs change enabling secondary distortion correction 
+  keywords. [#246]
+
+
 1.7.7 (2026-03-05)
 ------------------
 

--- a/stwcs/tests/test_headerlet.py
+++ b/stwcs/tests/test_headerlet.py
@@ -245,13 +245,13 @@ class TestApplyHeaderlet:
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [('SCI', 1), ('SCI', 2)],
                                         [("SIPWCS", 1), ("SIPWCS", 2)],
-                                        scikey='K', verbose=True)[0])
+                                        scikey='K', verbose=True, ignore_cpdisp=True)[0])
         headerlet.apply_headerlet_as_alternate(self.comp_file,
                                                self.headerlet_name, wcskey='P')
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [('SCI', 1), ('SCI', 2)],
                                         [("SIPWCS", 1), ("SIPWCS", 2)],
-                                        scikey='P', verbose=True)[0])
+                                        scikey='P', verbose=True, ignore_cpdisp=True)[0])
 
 class TestRestoreHeaderlet:
 

--- a/stwcs/tests/test_headerlet.py
+++ b/stwcs/tests/test_headerlet.py
@@ -245,13 +245,13 @@ class TestApplyHeaderlet:
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [('SCI', 1), ('SCI', 2)],
                                         [("SIPWCS", 1), ("SIPWCS", 2)],
-                                        scikey='K', verbose=True, ignore_cpdisp=True)[0])
+                                        scikey='K', verbose=True, ignore_cpdis=True)[0])
         headerlet.apply_headerlet_as_alternate(self.comp_file,
                                                self.headerlet_name, wcskey='P')
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [('SCI', 1), ('SCI', 2)],
                                         [("SIPWCS", 1), ("SIPWCS", 2)],
-                                        scikey='P', verbose=True, ignore_cpdisp=True)[0])
+                                        scikey='P', verbose=True, ignore_cpdis=True)[0])
 
 class TestRestoreHeaderlet:
 

--- a/stwcs/tests/test_headerlet.py
+++ b/stwcs/tests/test_headerlet.py
@@ -240,7 +240,15 @@ class TestApplyHeaderlet:
     @pytest.mark.skipif(os.name == "nt", reason="FIXME: Crash on Windows")
     def test_apply_as_alternate_method(self):
         hlet = headerlet.create_headerlet(self.comp_file, hdrname='test1')
+
+        # Make the headerlet WCS distinct from the current primary WCS
+        hlet['SIPWCS', 1].header['CRPIX1'] += 1
+        hlet['SIPWCS', 1].header['CRPIX2'] += 1
+        hlet['SIPWCS', 2].header['CRPIX1'] += 2
+        hlet['SIPWCS', 2].header['CRPIX2'] += 2
+
         hlet.apply_as_alternate(self.comp_file, wcskey='K', wcsname='KK')
+        assert fits.getval(self.comp_file, 'WCSNAMEK', ext=('SCI', 1)) == 'KK'
         hlet.writeto(self.headerlet_name, overwrite=True)
         assert(wcsdiff.is_wcs_identical(self.comp_file, self.headerlet_name,
                                         [('SCI', 1), ('SCI', 2)],

--- a/stwcs/wcsutil/wcsdiff.py
+++ b/stwcs/wcsutil/wcsdiff.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def is_wcs_identical(scifile, file2, sciextlist, fextlist, scikey=" ",
-                     file2key=" ", verbose=False):
+                     file2key=" ", ignore_cpdisp=False, verbose=False):
     """
     Compares the WCS solution of 2 files.
 
@@ -26,6 +26,8 @@ def is_wcs_identical(scifile, file2, sciextlist, fextlist, scikey=" ",
              alternate WCS key in scifile
     file2key: string
              alternate WCS key in file2
+    ignore_cpdisp: bool
+             True: ignore CPDIS1 and CPDIS2 when comparing WCS solutions
     verbose: bool
              True: print to stdout
 
@@ -83,21 +85,24 @@ def is_wcs_identical(scifile, file2, sciextlist, fextlist, scikey=" ",
                 # logger.info('SIP coefficients do not match')
                 diff['SIP_B'] = (w1.sip.b, w2.sip.b)
                 result = False
-        if w1.cpdis1 or w2.cpdis1:
-            if w1.cpdis1 and not w2.cpdis1 or w2.cpdis1 and not w1.cpdis1:
-                diff['CPDIS1'] = "CPDIS1 missing"
-                result = False
-            if w1.cpdis2 and not w2.cpdis2 or w2.cpdis2 and not w1.cpdis2:
-                diff['CPDIS2'] = "CPDIS2 missing"
-                result = False
-            if not np.allclose(w1.cpdis1.data, w2.cpdis1.data, rtol=10**(-7)):
-                # logger.info('NPOL distortions do not match')
-                diff['CPDIS1_data'] = (w1.cpdis1.data, w2.cpdis1.data)
-                result = False
-            if not np.allclose(w1.cpdis2.data, w2.cpdis2.data, rtol=10**(-7)):
-                # logger.info('NPOL distortions do not match')
-                diff['CPDIS2_data'] = (w1.cpdis2.data, w2.cpdis2.data)
-                result = False
+        if ignore_cpdisp:
+            pass
+        else:
+            if w1.cpdis1 or w2.cpdis1:
+                if w1.cpdis1 and not w2.cpdis1 or w2.cpdis1 and not w1.cpdis1:
+                    diff['CPDIS1'] = "CPDIS1 missing"
+                    result = False
+                if w1.cpdis2 and not w2.cpdis2 or w2.cpdis2 and not w1.cpdis2:
+                    diff['CPDIS2'] = "CPDIS2 missing"
+                    result = False
+                if not np.allclose(w1.cpdis1.data, w2.cpdis1.data, rtol=10**(-7)):
+                    # logger.info('NPOL distortions do not match')
+                    diff['CPDIS1_data'] = (w1.cpdis1.data, w2.cpdis1.data)
+                    result = False
+                if not np.allclose(w1.cpdis2.data, w2.cpdis2.data, rtol=10**(-7)):
+                    # logger.info('NPOL distortions do not match')
+                    diff['CPDIS2_data'] = (w1.cpdis2.data, w2.cpdis2.data)
+                    result = False
         if w1.det2im1 or w2.det2im1:
             if w1.det2im1 and not w2.det2im1 or \
                     w2.det2im1 and not w1.det2im1:

--- a/stwcs/wcsutil/wcsdiff.py
+++ b/stwcs/wcsutil/wcsdiff.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def is_wcs_identical(scifile, file2, sciextlist, fextlist, scikey=" ",
-                     file2key=" ", ignore_cpdisp=False, verbose=False):
+                     file2key=" ", ignore_cpdis=False, verbose=False):
     """
     Compares the WCS solution of 2 files.
 
@@ -26,7 +26,7 @@ def is_wcs_identical(scifile, file2, sciextlist, fextlist, scikey=" ",
              alternate WCS key in scifile
     file2key: string
              alternate WCS key in file2
-    ignore_cpdisp: bool
+    ignore_cpdis: bool
              True: ignore CPDIS1 and CPDIS2 when comparing WCS solutions
     verbose: bool
              True: print to stdout
@@ -85,7 +85,7 @@ def is_wcs_identical(scifile, file2, sciextlist, fextlist, scikey=" ",
                 # logger.info('SIP coefficients do not match')
                 diff['SIP_B'] = (w1.sip.b, w2.sip.b)
                 result = False
-        if ignore_cpdisp:
+        if ignore_cpdis:
             pass
         else:
             if w1.cpdis1 or w2.cpdis1:


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1587](https://jira.stsci.edu/browse/HLA-1587)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an issue arising from astropy [PR #19228](https://github.com/astropy/astropy/pull/19228). That PR enables the ability to load a secondary WCS with that secondary's distortion correction. Since this is not something we regularly do, we can generally ignore this change as the primary distortion is almost always used for HST. 

#19228 does change some code behavior in that when a secondary WCS solution is applied, the WCS solution will not have values for the header keywords `cpdis1` or `cpdis2`.  

The astropy PR was causing one of our tests to fail `test_apply_as_alternate_method` because the test was looking to make sure all relevant header keywords were the same. Since the `cpdis` keywords were None when applying a secondary, this was causing the failure. The solution is introduce a `ignore_cpdis` argument for the tests applying a secondary. 

**Checklist for maintainers**
- [x] added entry in `CHANGELOG.rst` within the relevant release section
- [x] updated or added relevant tests
- [x] updated relevant documentation
- [x] added relevant label(s)