### PR TITLE
HLA-1610: Scale missing from idctab bug 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+===================
+STWCS Release Notes
+===================
+
+
+1.7.8 (TBD)
+-----------
+
+- Bug fix for empty scale value returned from idctab [#249]
+
+
 1.7.7 (2026-03-05)
 ------------------
 

--- a/stwcs/distortion/utils.py
+++ b/stwcs/distortion/utils.py
@@ -111,12 +111,16 @@ def make_orthogonal_cd(wcs):
             pv += wcs.idctheta
         cs = np.cos(np.deg2rad(pv))
         sn = np.sin(np.deg2rad(pv))
+        
         pvmat = np.dot(np.array([[cs, sn], [-sn, cs]]), wcs.parity)
         rot = np.arctan2(pvmat[0, 1], pvmat[1, 1])
 
         det = linalg.det(wcs.parity)
         if hasattr(wcs, 'idcscale') and wcs.idcscale is not None:
             scale = (wcs.idcscale) / 3600.  # HST pixel scale provided
+        else:
+            warnings.warn("IDCSCALE is missing, computing it from CD matrix.")
+            scale = np.sqrt(np.abs(det))  # find as sqrt(pixel area)
     else:
 
         det = linalg.det(cd)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1610](https://jira.stsci.edu/browse/HLA-1610)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses an edge case bug where the pixel scale (pulled from the idctab) returns nothing. In this situation (idan47020_asn.fits) we have discovered `idcv2ref` was available, but not `idcscale`.  

If both `idcv2ref` and `idcscale` are missing, scale is calculated using the determinant of the CD matrix. I have added a line to similarly calculate scale if `idcv2ref` alone is missing. 

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)